### PR TITLE
DBTP-137 Support different tagged versions in `ci-image-builder` repo

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ set -x
 
 ECR_PATH="public.ecr.aws/uktrade"
 
-BUILDER_VERSION="${BUILDER_VERSION:-0.2.326-full}"
+BUILDER_VERSION="${BUILDER_VERSION:=0.2.326-full}"
 LIFECYCLE_VERSION="0.16.0"
 RUN_VERSION="full-cnb"
 

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ set -x
 
 ECR_PATH="public.ecr.aws/uktrade"
 
-BUILDER_VERSION="0.2.326-full"
+BUILDER_VERSION="${DEPLOY_ENV:-0.2.326-full}"
 LIFECYCLE_VERSION="0.16.0"
 RUN_VERSION="full-cnb"
 

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ set -x
 
 ECR_PATH="public.ecr.aws/uktrade"
 
-BUILDER_VERSION="${DEPLOY_ENV:-0.2.326-full}"
+BUILDER_VERSION="${BUILDER_VERSION:-0.2.326-full}"
 LIFECYCLE_VERSION="0.16.0"
 RUN_VERSION="full-cnb"
 


### PR DESCRIPTION
Provide option to pass in BUILDER_VERSION as env variable, rather than hardcoding it.

