### PR TITLE
pass image-scanning-configuration flag

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -75,7 +75,7 @@ do
   # If ECR repo does not exist create it
   aws ecr describe-repositories --repository-names "${APP_NAME}"/"${PROC}" --region eu-west-2 >/dev/null
   status=$?
-  [ $status -ne 0 ] && aws ecr create-repository --repository-name "${APP_NAME}"/"${PROC}" --region eu-west-2
+  [ $status -ne 0 ] && aws ecr create-repository --repository-name "${APP_NAME}"/"${PROC}" --region eu-west-2 --image-scanning-configuration scanOnPush=true
 
   # Build image and push to ECR
   IMAGE="${DOCKERREG}"/"${APP_NAME}"/"${PROC}"


### PR DESCRIPTION
Trusted advisor complains that we have ecr repos not using image scanning:

<img width="1173" alt="Screenshot 2023-07-13 at 12 03 27" src="https://github.com/uktrade/ci-image-builder/assets/46938749/177997a3-9211-45db-bacd-a24b2e0eae9d">

Separate task to switch it on for existing repos