### PR TITLE
Refactor: Rename `BUILDER_VERSION` -> `PAKETO_BUILDER_VERSION`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:4.0
 
 ARG PACK_VERSION
-ARG BUILDER_VERSION
+ARG PAKETO_BUILDER_VERSION
 ARG LIFECYCLE_VERSION
 
 RUN yum install -y jq
@@ -18,7 +18,7 @@ RUN mkdir /docker_images
 COPY build.sh /work/build.sh
 RUN chmod +x /work/build.sh
 
-RUN echo ${BUILDER_VERSION} > /work/builder-version.txt
+RUN echo ${PAKETO_BUILDER_VERSION} > /work/builder-version.txt
 RUN echo ${LIFECYCLE_VERSION} > /work/lifecycle-version.txt
 
 COPY builder-post.sh /work/builder-post.sh

--- a/README.md
+++ b/README.md
@@ -4,23 +4,23 @@ Docker image for building OCI images using Paketo buildpacks and uploading them 
 
 ## Usage
 
-This is designed to be used by AWS CodeBuild projects
+This is designed to be used by AWS CodeBuild projects.
 
-1. Environment image, update this to the location of your uploaded Docker image of the `ci-image-builder`.
+1. Environment image - update this to the location of your uploaded Docker image of the `ci-image-builder`.
+2. Buildspec - this will normally point to the location of your source codes `buildspec.yml` file.
+3. Include 3 environment variables in the CodeBuild projects environment section, which indicate the versions of binaries and buildpacks to use.
 
-2. Buildspec, this will normally point to the location of your source codes `buildspec.yml` file.  
-
-3. Include 3 environment variables in the CodeBuild projects environment section, which indicate the versions of binaries and buildpacks to use. eg.
+For example...
 
 ```
 PACK_VERSION = v0.28.0
-BUILDER_VERSION = 0.2.326-full
+PAKETO_BUILDER_VERSION = 0.2.395-full
 LIFECYCLE_VERSION = 0.16.0
 ```
 
-AWS Reference:  https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html
+AWS Reference: https://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html
 
-### buildspec.yml
+### `buildspec.yml`
 
 ```yml
 version: 0.2
@@ -43,29 +43,29 @@ phases:
       - /work/build.sh
 ```
 
-#### ENV VARS
+#### Environment Variables
 
-`SLACK_* - Credentials/ IDS needed to interact with SLACK`
+`SLACK_*` - Credentials/IDs needed to interact with Slack.
 
-`ECR_VISIBILITY - If set to PUBLIC then OCI image will be placed in a public repo in the AWS account, if not set this will default to PRIVATE`
+`ECR_VISIBILITY` - If set to `PUBLIC`, then the OCI image will be placed in a public repo in the AWS account, and if not set this will default to PRIVATE.
 
-#### PHASES
+#### Phases
 
-It is possible to run multiple phases for you build, in most cases the example above will be sufficient. 
+It is possible to run multiple phases for your build, but in most cases, the example above will be sufficient.
 
-If you need to install additional packages into the image you can add that to the Install section.
+If you need to install additional packages into the image, you can add that to the `install` section. Refer to the AWS reference for more details.
 
-Under `pre-build` we suggest including a breakpoint, this can be useful for troubleshooting the container. This can be enabled when you `Start build with overrides`, in the AWS console.
+Under `pre-build`, we suggest including a breakpoint, this can be useful for troubleshooting the container. This can be enabled when you `Start build with overrides`, in the AWS console.
 
-Finally, under build, the path to the `ci-image-builder`'s `build.sh` script is defined.  
+Finally, under `build`, the path to the `ci-image-builder`'s `build.sh` script is defined.  
 
 ## Instructions to deploy a public image
 
 In order to deploy a public image rather than the default private image do the following.
 
-In your `buildspec.yml` file add set the variable `ECR_VISIBILITY: PUBLIC`
+In your `buildspec.yml` file, add and set the variable `ECR_VISIBILITY: PUBLIC`
 
-In your codes repo `process.yml` specify your public image name.
+In your repository, in the `process.yml` file, specify your public image name.
 
 ```yml
 application:
@@ -91,9 +91,9 @@ This will produce:
 
 `public.ecr.aws/{aws alias}/image_name/app_name:latest`
 
-### Using copilot-tools to build images
+### Using `copilot-tools` to build images
 
-Finally, to have CodeBuild watch your application repo and deploy an OCI image on changes, run the following commands:
+Finally, to have CodeBuild watch your application repo and deploy an OCI image on GitHub changes, run the following commands:
 
 ```
 aws sso login --profile profile-name && export AWS_PROFILE=profile-name

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ set -x
 
 LOG_LEVEL="DEBUG"
 
-# Set env VAR to PUBLICfor public images
+# Set env VAR to PUBLIC for public images
 ECR_VISIBILITY="${ECR_VISIBILITY:=PRIVATE}"
 
 ECR_PATH="public.ecr.aws/uktrade"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -19,10 +19,10 @@ phases:
     commands:
     - echo Build started on `date`
     - echo Building the Docker image...
-    - docker build --build-arg PACK_VERSION=${PACK_VERSION} --build-arg BUILDER_VERSION=${BUILDER_VERSION} --build-arg LIFECYCLE_VERSION=${LIFECYCLE_VERSION} -t $REPOSITORY_URI .
+    - docker build --build-arg PACK_VERSION=${PACK_VERSION} --build-arg PAKETO_BUILDER_VERSION=${PAKETO_BUILDER_VERSION} --build-arg LIFECYCLE_VERSION=${LIFECYCLE_VERSION} -t $REPOSITORY_URI .
     - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
     - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$GIT_BRANCH
-    - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$BUILDER_VERSION
+    - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$PAKETO_BUILDER_VERSION
 
   post_build:
     commands:


### PR DESCRIPTION
## Context

- Make `BUILDER_VERSION` more apparent, so we know it is the Paketo builder version.
  - There was confusion around whether it was the `ci-image-builder` version or the Paketo builder version.