### PR TITLE
fix: fail a build with no buildpacks

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -50,7 +50,7 @@ if [ -f $BUILDPACK_JSON ]; then
 fi
 
 if [ -z "$BUILDPACKS" ]; then
-  echo "Your \"$BUILDPACK_JSON\" file contains no build packs, you must add at least one."
+  echo "Found no build packs in file \"$BUILDPACK_JSON\", you must add at least one."
   exit 1
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -46,7 +46,7 @@ if [ -f $BUILDPACK_JSON ]; then
       BUILDPACKS+=" --buildpack $KEY/$VALUE"
     done
   else
-    echo "Ensure your \"$BUILDPACK_JSON\" file contains the \"buildpacks\" property."
+    echo "Your \"$BUILDPACK_JSON\" file contains no buildpacks, check the \"buildpacks\" property."
   fi
 else
   BUILDPACKS=""

--- a/build.sh
+++ b/build.sh
@@ -18,6 +18,7 @@ BUILDER_RUN="$BUILDPACKS_PATH/run:$RUN_VERSION"
 LIFECYCLE="$ECR_PATH/buildpacksio/lifecycle:$LIFECYCLE_VERSION"
 BUILDPACK_JSON="buildpack.json"
 BUILDPACK_POST="fagiani/run@0.1.1"
+BUILDPACKS=""
 
 GIT_TAG=$(git describe --tags --abbrev=0)
 GIT_COMMIT=$(echo "$CODEBUILD_RESOLVED_SOURCE_VERSION" | cut -c1-7)
@@ -45,12 +46,11 @@ if [ -f $BUILDPACK_JSON ]; then
 
       BUILDPACKS+=" --buildpack $KEY/$VALUE"
     done
-  else
-    echo "Your \"$BUILDPACK_JSON\" file contains no buildpacks, check the \"buildpacks\" property."
-    exit 1
   fi
-else
-  echo "No \"$BULDPACK_JSON\" file found, exiting..."
+fi
+
+if [ -z "$BUILDPACKS" ]; then
+  echo "Your \"$BUILDPACK_JSON\" file contains no build packs, you must add at least one."
   exit 1
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -47,9 +47,11 @@ if [ -f $BUILDPACK_JSON ]; then
     done
   else
     echo "Your \"$BUILDPACK_JSON\" file contains no buildpacks, check the \"buildpacks\" property."
+    exit 1
   fi
 else
-  BUILDPACKS=""
+  echo "No \"$BULDPACK_JSON\" file found, exiting..."
+  exit 1
 fi
 
 if [ -f "runtime.txt" ]; then


### PR DESCRIPTION
# What?

If the buildpack JSON file is missing or does not contain any buildpacks, fail the build.

# Why?

Currently a build with no buildpacks will produce a useless image without buildpacks.

# How?

Add `exit 1` to each failure condition.