### PR TITLE
Add `PACK_VERSION` to buildspec configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Docker image for building OCI images using Paketo buildpacks and uploading them 
 
 ## Build
 
-An environment variable for [`Pack CLI version`](https://github.com/buildpacks/pack/releases) has to be set in the environment settings within the CI Image Builder AWS CodeBuild project console, for example:
+An environment variable for the [`Pack CLI version`](https://github.com/buildpacks/pack/releases) has to be set in the [`buildspec.yml`](buildspec.yml) file.
 
-    PACK_VERSION = v0.28.0
+The CodeBuild project for the `ci-image-builder` is managed via Terraform in the `terraform-tools` GitLab repository.
 
 ## Usage
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,4 +1,9 @@
 version: 0.2
+
+env:
+  variables:
+    PACK_VERSION: v0.28.0
+
 phases:
   install:
     runtime-versions:


### PR DESCRIPTION
## Context

- Add `PACK_VERSION` to buildspec configuration
  - Terraform manages the CodeBuild project, so manually adding the env var in the CodeBuild console will mean it gets removed upon every `terraform apply` as it is not set there.
- Update documentation