### PR TITLE
Update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:4.0
+FROM public.ecr.aws/codebuild/amazonlinux2023-x86_64-standard:4.0
 
 ARG PACK_VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/codebuild/amazonlinux2023-x86_64-standard:4.0
+FROM public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0
 
 ARG PACK_VERSION
 


### PR DESCRIPTION
Part of this [ticket](https://uktrade.atlassian.net/browse/DBTP-482). We still need a way of automating updates to fix package vulnerabilities identified by image scanner, which will probably have to wait until we move to latest version of buildpacks.