### PR TITLE
DBTP-464 When an image is built from a git tag, also tag with `tag-latest`

### DIFF
--- a/image_builder/pack.py
+++ b/image_builder/pack.py
@@ -94,6 +94,7 @@ class Pack:
         tags = [f"commit-{self.codebase.revision.commit}"]
         if self.codebase.revision.tag:
             tags.append(f"tag-{self.codebase.revision.tag}")
+            tags.append(f"tag-latest")
 
         if self.codebase.revision.branch:
             tags.append(f"branch-{self.codebase.revision.branch.replace('/', '-')}")

--- a/test/image_builder/test_pack.py
+++ b/test/image_builder/test_pack.py
@@ -207,7 +207,8 @@ class TestPackTags(TestCase):
         pack = Pack(codebase)
 
         self.assertEqual(
-            pack.get_tags(), ["commit-shorthash", "tag-v2.4.6", "branch-feat-tests"]
+            pack.get_tags(),
+            ["commit-shorthash", "tag-v2.4.6", "tag-latest", "branch-feat-tests"],
         )
 
 
@@ -276,6 +277,7 @@ class TestCommand(TestCase):
             "--builder paketobuildpacks/builder-jammy-full:0.3.288 "
             "--tag 000000000000.dkr.ecr.region.amazonaws.com/ecr/repos:commit-shorthash "
             "--tag 000000000000.dkr.ecr.region.amazonaws.com/ecr/repos:tag-v2.4.6 "
+            "--tag 000000000000.dkr.ecr.region.amazonaws.com/ecr/repos:tag-latest "
             "--tag 000000000000.dkr.ecr.region.amazonaws.com/ecr/repos:branch-feat-tests "
             "--env BP_CPYTHON_VERSION=3.11 "
             "--env BP_NODE_VERSION=20.7 "
@@ -304,6 +306,7 @@ class TestCommand(TestCase):
             "--builder paketobuildpacks/builder-jammy-full:0.3.288 "
             "--tag 000000000000.dkr.ecr.region.amazonaws.com/ecr/repos:commit-shorthash "
             "--tag 000000000000.dkr.ecr.region.amazonaws.com/ecr/repos:tag-v2.4.6 "
+            "--tag 000000000000.dkr.ecr.region.amazonaws.com/ecr/repos:tag-latest "
             "--tag 000000000000.dkr.ecr.region.amazonaws.com/ecr/repos:branch-feat-tests "
             "--env BP_CPYTHON_VERSION=3.11 "
             "--env BP_NODE_VERSION=20.7 "
@@ -333,6 +336,7 @@ class TestCommand(TestCase):
             "--builder paketobuildpacks/builder-jammy-full:0.3.288 "
             "--tag 000000000000.dkr.ecr.region.amazonaws.com/ecr/repos:commit-shorthash "
             "--tag 000000000000.dkr.ecr.region.amazonaws.com/ecr/repos:tag-v2.4.6 "
+            "--tag 000000000000.dkr.ecr.region.amazonaws.com/ecr/repos:tag-latest "
             "--tag 000000000000.dkr.ecr.region.amazonaws.com/ecr/repos:branch-feat-tests "
             "--env BP_CPYTHON_VERSION=3.11 "
             "--env BP_NODE_VERSION=20.7 "


### PR DESCRIPTION
This will allow us to trigger tag pipelines without having to do any hacks with lambdas in the code pipeline.