### PR TITLE
DBTP-386 - Add OCI labels to built images for fun and other reasons

### DIFF
--- a/image_builder/commands.py
+++ b/image_builder/commands.py
@@ -9,9 +9,12 @@ from image_builder.progress import Progress
 
 @click.command("build", help="Build an image")
 @click.option("--publish", is_flag=True, default=False, help="Publish the built image")
-def build(publish):
+@click.option(
+    "--send-notifications", is_flag=True, default=False, help="Send slack notifications"
+)
+def build(publish, send_notifications):
     codebase = Codebase(".")
-    notify = Notify(codebase)
+    notify = Notify(codebase, send_notifications)
     progress = Progress()
     pack = Pack(codebase)
     progress.current_phase_running()

--- a/image_builder/commands.py
+++ b/image_builder/commands.py
@@ -16,9 +16,9 @@ def build(publish, send_notifications):
     codebase = Codebase(".")
     notify = Notify(codebase, send_notifications)
     progress = Progress()
-    pack = Pack(codebase)
     progress.current_phase_running()
     notify.post_progress(progress)
+    pack = Pack(codebase, notify.reference)
 
     try:
         if not Docker.running():

--- a/image_builder/notify.py
+++ b/image_builder/notify.py
@@ -18,95 +18,102 @@ class Notify:
     reference: str
     settings: Settings
 
-    def __init__(self, codebase: Codebase):
+    def __init__(self, codebase: Codebase, send_notifications: bool = True):
         self.settings = Settings()
         self.codebase = codebase
-        try:
-            self.slack = WebClient(token=os.environ["SLACK_TOKEN"])
-            self.settings.channel = os.environ["SLACK_CHANNEL_ID"]
-            self.settings.build_arn = os.environ["CODEBUILD_BUILD_ARN"]
-        except KeyError as e:
-            raise ValueError(f"{e} environment variable must be set")
+        self.send_notifications = send_notifications
+
+        if self.send_notifications:
+            try:
+                self.slack = WebClient(token=os.environ["SLACK_TOKEN"])
+                self.settings.channel = os.environ["SLACK_CHANNEL_ID"]
+                self.settings.build_arn = os.environ["CODEBUILD_BUILD_ARN"]
+            except KeyError as e:
+                raise ValueError(f"{e} environment variable must be set")
 
     def post_progress(self, progress: Progress):
-        message_headline = (
-            f"*Building {self.codebase.revision.get_repository_name()}@"
-            f"{self.codebase.revision.commit}*"
-        )
-        message_repository = (
-            f"*Repository*: <{self.codebase.revision.get_repository_url()}|"
-            f"{self.codebase.revision.get_repository_name()}>"
-        )
-        message_revision = (
-            f"*Revision*: <{self.codebase.revision.get_repository_url()}/commit/"
-            f"{self.codebase.revision.commit}|{self.codebase.revision.commit}>"
-        )
-        message_build_logs = f"<{self.get_build_url()}|Build Logs>"
+        if self.send_notifications:
+            message_headline = (
+                f"*Building {self.codebase.revision.get_repository_name()}@"
+                f"{self.codebase.revision.commit}*"
+            )
+            message_repository = (
+                f"*Repository*: <{self.codebase.revision.get_repository_url()}|"
+                f"{self.codebase.revision.get_repository_name()}>"
+            )
+            message_revision = (
+                f"*Revision*: <{self.codebase.revision.get_repository_url()}/commit/"
+                f"{self.codebase.revision.commit}|{self.codebase.revision.commit}>"
+            )
+            message_build_logs = f"<{self.get_build_url()}|Build Logs>"
 
-        message_blocks = [
-            blocks.SectionBlock(
-                text=blocks.TextObject(type="mrkdwn", text=message_headline),
-            ),
-            blocks.ContextBlock(
-                elements=[
-                    blocks.TextObject(type="mrkdwn", text=message_repository),
-                    blocks.TextObject(type="mrkdwn", text=message_revision),
-                ]
-            ),
-            blocks.SectionBlock(
-                text=blocks.TextObject(
-                    type="mrkdwn", text=f'{progress.get_phase("setup")}'
+            message_blocks = [
+                blocks.SectionBlock(
+                    text=blocks.TextObject(type="mrkdwn", text=message_headline),
+                ),
+                blocks.ContextBlock(
+                    elements=[
+                        blocks.TextObject(type="mrkdwn", text=message_repository),
+                        blocks.TextObject(type="mrkdwn", text=message_revision),
+                    ]
+                ),
+                blocks.SectionBlock(
+                    text=blocks.TextObject(
+                        type="mrkdwn", text=f'{progress.get_phase("setup")}'
+                    )
+                ),
+                blocks.SectionBlock(
+                    text=blocks.TextObject(
+                        type="mrkdwn", text=f'{progress.get_phase("build")}'
+                    )
+                ),
+                blocks.SectionBlock(
+                    text=blocks.TextObject(
+                        type="mrkdwn", text=f'{progress.get_phase("publish")}'
+                    )
+                ),
+                blocks.ContextBlock(
+                    elements=[
+                        blocks.TextObject(type="mrkdwn", text=message_build_logs),
+                    ]
+                ),
+            ]
+            if hasattr(self, "reference"):
+                response = self.slack.chat_update(
+                    channel=os.environ["SLACK_CHANNEL_ID"],
+                    blocks=message_blocks,
+                    ts=self.reference,
+                    text=f"Building: {self.codebase.revision.get_repository_name()}@{self.codebase.revision.commit}",
+                    unfurl_links=False,
+                    unfurl_media=False,
                 )
-            ),
-            blocks.SectionBlock(
-                text=blocks.TextObject(
-                    type="mrkdwn", text=f'{progress.get_phase("build")}'
+                self.reference = response["ts"]
+            else:
+                response = self.slack.chat_postMessage(
+                    channel=os.environ["SLACK_CHANNEL_ID"],
+                    blocks=message_blocks,
+                    text=f"Building: {self.codebase.revision.get_repository_name()}@{self.codebase.revision.commit}",
+                    unfurl_links=False,
+                    unfurl_media=False,
                 )
-            ),
-            blocks.SectionBlock(
-                text=blocks.TextObject(
-                    type="mrkdwn", text=f'{progress.get_phase("publish")}'
-                )
-            ),
-            blocks.ContextBlock(
-                elements=[
-                    blocks.TextObject(type="mrkdwn", text=message_build_logs),
-                ]
-            ),
-        ]
-        if hasattr(self, "reference"):
-            response = self.slack.chat_update(
-                channel=os.environ["SLACK_CHANNEL_ID"],
-                blocks=message_blocks,
-                ts=self.reference,
-                text=f"Building: {self.codebase.revision.get_repository_name()}@{self.codebase.revision.commit}",
-                unfurl_links=False,
-                unfurl_media=False,
-            )
-            self.reference = response["ts"]
-        else:
-            response = self.slack.chat_postMessage(
-                channel=os.environ["SLACK_CHANNEL_ID"],
-                blocks=message_blocks,
-                text=f"Building: {self.codebase.revision.get_repository_name()}@{self.codebase.revision.commit}",
-                unfurl_links=False,
-                unfurl_media=False,
-            )
-            self.reference = response["ts"]
+                self.reference = response["ts"]
 
     def post_job_comment(self, message):
-        self.slack.chat_postMessage(
-            channel=os.environ["SLACK_CHANNEL_ID"],
-            blocks=[
-                blocks.SectionBlock(text=blocks.TextObject(type="mrkdwn", text=line))
-                for line in message
-                if line
-            ],
-            text=f"Build: {self.codebase.revision.get_repository_name()}@{self.codebase.revision.commit} update",
-            unfurl_links=False,
-            unfurl_media=False,
-            thread_ts=self.reference,
-        )
+        if self.send_notifications:
+            self.slack.chat_postMessage(
+                channel=os.environ["SLACK_CHANNEL_ID"],
+                blocks=[
+                    blocks.SectionBlock(
+                        text=blocks.TextObject(type="mrkdwn", text=line)
+                    )
+                    for line in message
+                    if line
+                ],
+                text=f"Build: {self.codebase.revision.get_repository_name()}@{self.codebase.revision.commit} update",
+                unfurl_links=False,
+                unfurl_media=False,
+                thread_ts=self.reference,
+            )
 
     def get_build_url(self):
         build_arn = self.settings.build_arn

--- a/image_builder/notify.py
+++ b/image_builder/notify.py
@@ -15,13 +15,14 @@ class Settings:
 
 class Notify:
     codebase: Codebase
-    reference: str
+    reference: str | None
     settings: Settings
 
     def __init__(self, codebase: Codebase, send_notifications: bool = True):
         self.settings = Settings()
         self.codebase = codebase
         self.send_notifications = send_notifications
+        self.reference = None
 
         if self.send_notifications:
             try:
@@ -78,20 +79,20 @@ class Notify:
                     ]
                 ),
             ]
-            if hasattr(self, "reference"):
-                response = self.slack.chat_update(
+            if self.reference is None:
+                response = self.slack.chat_postMessage(
                     channel=os.environ["SLACK_CHANNEL_ID"],
                     blocks=message_blocks,
-                    ts=self.reference,
                     text=f"Building: {self.codebase.revision.get_repository_name()}@{self.codebase.revision.commit}",
                     unfurl_links=False,
                     unfurl_media=False,
                 )
                 self.reference = response["ts"]
             else:
-                response = self.slack.chat_postMessage(
+                response = self.slack.chat_update(
                     channel=os.environ["SLACK_CHANNEL_ID"],
                     blocks=message_blocks,
+                    ts=self.reference,
                     text=f"Building: {self.codebase.revision.get_repository_name()}@{self.codebase.revision.commit}",
                     unfurl_links=False,
                     unfurl_media=False,

--- a/image_builder/pack.py
+++ b/image_builder/pack.py
@@ -92,6 +92,9 @@ class Pack:
             environment.append(f"GIT_BRANCH={self.codebase.revision.branch}")
 
         environment.append(f"BP_OCI_REF_NAME={self.codebase.build.repository}")
+        environment.append(
+            f"BP_OCI_SOURCE={self.codebase.revision.get_repository_url()}"
+        )
 
         return environment
 

--- a/image_builder/pack.py
+++ b/image_builder/pack.py
@@ -15,9 +15,11 @@ class PackCommandFailedError(PackError):
 
 class Pack:
     codebase: Codebase
+    build_timestamp: str
 
-    def __init__(self, codebase: Codebase):
+    def __init__(self, codebase: Codebase, build_timestamp: str = None):
         self.codebase = codebase
+        self.build_timestamp = build_timestamp
 
     def build(
         self, publish=False, on_building: Callable = None, on_exporting: Callable = None
@@ -96,6 +98,17 @@ class Pack:
         environment.append(
             f"BP_OCI_SOURCE={self.codebase.revision.get_repository_url()}"
         )
+
+        additional_labels = []
+
+        if self.build_timestamp is not None:
+            additional_labels.append(
+                f"uk.gov.trade.digital.build.timestamp={self.build_timestamp}"
+            )
+
+        if additional_labels:
+            additional_labels = " ".join(additional_labels)
+            environment.append(f'BP_IMAGE_LABELS="{additional_labels}"')
 
         return environment
 

--- a/image_builder/pack.py
+++ b/image_builder/pack.py
@@ -33,6 +33,7 @@ class Pack:
                 on_building()
             if on_exporting is not None and "===> EXPORTING" in output:
                 on_exporting()
+
         if proc.returncode != 0:
             raise PackCommandFailedError
 
@@ -110,7 +111,10 @@ class Pack:
         return tags
 
     def get_repository(self):
-        _, _, _, region, account, _, _ = os.environ["CODEBUILD_BUILD_ARN"].split(":")
-        return (
-            f"{account}.dkr.ecr.{region}.amazonaws.com/{self.codebase.build.repository}"
-        )
+        if "CODEBUILD_BUILD_ARN" in os.environ:
+            _, _, _, region, account, _, _ = os.environ["CODEBUILD_BUILD_ARN"].split(
+                ":"
+            )
+            return f"{account}.dkr.ecr.{region}.amazonaws.com/{self.codebase.build.repository}"
+
+        return self.codebase.build.repository

--- a/image_builder/pack.py
+++ b/image_builder/pack.py
@@ -65,6 +65,7 @@ class Pack:
                 buildpacks.append("paketo-buildpacks/nodejs")
 
         buildpacks.append("fagiani/run")
+        buildpacks.append("gcr.io/paketo-buildpacks/image-labels")
 
         return buildpacks
 
@@ -84,9 +85,13 @@ class Pack:
 
         if self.codebase.revision.commit:
             environment.append(f"GIT_COMMIT={self.codebase.revision.commit}")
+            environment.append(f"BP_OCI_REVISION={self.codebase.revision.commit}")
+            environment.append(f"BP_OCI_VERSION={self.codebase.revision.commit}")
 
         if self.codebase.revision.branch:
             environment.append(f"GIT_BRANCH={self.codebase.revision.branch}")
+
+        environment.append(f"BP_OCI_REF_NAME={self.codebase.build.repository}")
 
         return environment
 

--- a/test/image_builder/test_commands.py
+++ b/test/image_builder/test_commands.py
@@ -35,7 +35,7 @@ class TestBuildCommand(unittest.TestCase):
 
     def run_build(self):
         runner = CliRunner()
-        result = runner.invoke(build)
+        result = runner.invoke(build, ["--send-notifications"])
         return result
 
     def test_perfect_build(self, pack, docker, codebase, notify, progress):

--- a/test/image_builder/test_notify.py
+++ b/test/image_builder/test_notify.py
@@ -84,6 +84,12 @@ class TestNotify(unittest.TestCase):
             unfurl_media=False,
         )
 
+    def test_sending_progress_updates_when_notifications_off(self, webclient, time):
+        notify = Notify(self.codebase, False)
+        progress = Progress()
+        notify.post_progress(progress)
+        self.assertFalse(hasattr(notify, "slack"))
+
     def test_sending_all_build_stages_successful(self, webclient, time):
         notify = Notify(self.codebase)
         progress = Progress()

--- a/test/image_builder/test_pack.py
+++ b/test/image_builder/test_pack.py
@@ -150,7 +150,7 @@ class TestPackEnvironment(TestCase):
         )
 
         codebase = Codebase(Path("."))
-        pack = Pack(codebase)
+        pack = Pack(codebase, "timestamp")
 
         self.assertEqual(
             pack.get_environment(),
@@ -164,6 +164,7 @@ class TestPackEnvironment(TestCase):
                 "GIT_BRANCH=feat/tests",
                 "BP_OCI_REF_NAME=ecr/repos",
                 "BP_OCI_SOURCE=https://github.com/org/repo",
+                'BP_IMAGE_LABELS="uk.gov.trade.digital.build.timestamp=timestamp"',
             ],
         )
 
@@ -276,7 +277,7 @@ class TestCommand(TestCase):
         load_codebase_languages,
     ):
         codebase = Codebase(Path("."))
-        pack = Pack(codebase)
+        pack = Pack(codebase, "timestamp")
         self.assertEqual(
             pack.get_command(),
             "pack build 000000000000.dkr.ecr.region.amazonaws.com/ecr/repos "
@@ -294,6 +295,7 @@ class TestCommand(TestCase):
             "--env GIT_BRANCH=feat/tests "
             "--env BP_OCI_REF_NAME=ecr/repos "
             "--env BP_OCI_SOURCE=https://github.com/org/repo "
+            '--env BP_IMAGE_LABELS="uk.gov.trade.digital.build.timestamp=timestamp" '
             "--buildpack fagiani/apt "
             "--buildpack paketo-buildpacks/git "
             "--buildpack paketo-buildpacks/python "
@@ -310,7 +312,7 @@ class TestCommand(TestCase):
         load_codebase_languages,
     ):
         codebase = Codebase(Path("."))
-        pack = Pack(codebase)
+        pack = Pack(codebase, "timestamp")
         self.assertEqual(
             pack.get_command(True),
             "pack build 000000000000.dkr.ecr.region.amazonaws.com/ecr/repos "
@@ -328,6 +330,7 @@ class TestCommand(TestCase):
             "--env GIT_BRANCH=feat/tests "
             "--env BP_OCI_REF_NAME=ecr/repos "
             "--env BP_OCI_SOURCE=https://github.com/org/repo "
+            '--env BP_IMAGE_LABELS="uk.gov.trade.digital.build.timestamp=timestamp" '
             "--buildpack fagiani/apt "
             "--buildpack paketo-buildpacks/git "
             "--buildpack paketo-buildpacks/python "
@@ -345,7 +348,7 @@ class TestCommand(TestCase):
         load_codebase_languages,
     ):
         codebase = Codebase(Path("."))
-        pack = Pack(codebase)
+        pack = Pack(codebase, "timestamp")
         pack.build()
         subprocess_popen.assert_called_with(
             "pack build 000000000000.dkr.ecr.region.amazonaws.com/ecr/repos "
@@ -363,6 +366,7 @@ class TestCommand(TestCase):
             "--env GIT_BRANCH=feat/tests "
             "--env BP_OCI_REF_NAME=ecr/repos "
             "--env BP_OCI_SOURCE=https://github.com/org/repo "
+            '--env BP_IMAGE_LABELS="uk.gov.trade.digital.build.timestamp=timestamp" '
             "--buildpack fagiani/apt "
             "--buildpack paketo-buildpacks/git "
             "--buildpack paketo-buildpacks/python "

--- a/test/image_builder/test_pack.py
+++ b/test/image_builder/test_pack.py
@@ -70,6 +70,7 @@ class TestPackBuildpacks(TestCase):
                 "paketo-buildpacks/python",
                 "paketo-buildpacks/nodejs",
                 "fagiani/run",
+                "gcr.io/paketo-buildpacks/image-labels",
             ],
         )
 
@@ -101,6 +102,7 @@ class TestPackBuildpacks(TestCase):
                 "paketo-buildpacks/python",
                 "paketo-buildpacks/nodejs",
                 "fagiani/run",
+                "gcr.io/paketo-buildpacks/image-labels",
             ],
         )
 
@@ -157,7 +159,10 @@ class TestPackEnvironment(TestCase):
                 "BP_NODE_VERSION=20.7",
                 "GIT_TAG=v2.4.6",
                 "GIT_COMMIT=shorthash",
+                "BP_OCI_REVISION=shorthash",
+                "BP_OCI_VERSION=shorthash",
                 "GIT_BRANCH=feat/tests",
+                "BP_OCI_REF_NAME=ecr/repos",
             ],
         )
 
@@ -283,12 +288,16 @@ class TestCommand(TestCase):
             "--env BP_NODE_VERSION=20.7 "
             "--env GIT_TAG=v2.4.6 "
             "--env GIT_COMMIT=shorthash "
+            "--env BP_OCI_REVISION=shorthash "
+            "--env BP_OCI_VERSION=shorthash "
             "--env GIT_BRANCH=feat/tests "
+            "--env BP_OCI_REF_NAME=ecr/repos "
             "--buildpack fagiani/apt "
             "--buildpack paketo-buildpacks/git "
             "--buildpack paketo-buildpacks/python "
             "--buildpack paketo-buildpacks/nodejs "
-            "--buildpack fagiani/run ",
+            "--buildpack fagiani/run "
+            "--buildpack gcr.io/paketo-buildpacks/image-labels ",
         )
 
     def test_get_command_with_publish(
@@ -312,12 +321,16 @@ class TestCommand(TestCase):
             "--env BP_NODE_VERSION=20.7 "
             "--env GIT_TAG=v2.4.6 "
             "--env GIT_COMMIT=shorthash "
+            "--env BP_OCI_REVISION=shorthash "
+            "--env BP_OCI_VERSION=shorthash "
             "--env GIT_BRANCH=feat/tests "
+            "--env BP_OCI_REF_NAME=ecr/repos "
             "--buildpack fagiani/apt "
             "--buildpack paketo-buildpacks/git "
             "--buildpack paketo-buildpacks/python "
             "--buildpack paketo-buildpacks/nodejs "
             "--buildpack fagiani/run "
+            "--buildpack gcr.io/paketo-buildpacks/image-labels "
             "--publish --cache-image 000000000000.dkr.ecr.region.amazonaws.com/ecr/repos:cache",
         )
 
@@ -342,12 +355,16 @@ class TestCommand(TestCase):
             "--env BP_NODE_VERSION=20.7 "
             "--env GIT_TAG=v2.4.6 "
             "--env GIT_COMMIT=shorthash "
+            "--env BP_OCI_REVISION=shorthash "
+            "--env BP_OCI_VERSION=shorthash "
             "--env GIT_BRANCH=feat/tests "
+            "--env BP_OCI_REF_NAME=ecr/repos "
             "--buildpack fagiani/apt "
             "--buildpack paketo-buildpacks/git "
             "--buildpack paketo-buildpacks/python "
             "--buildpack paketo-buildpacks/nodejs "
-            "--buildpack fagiani/run ",
+            "--buildpack fagiani/run "
+            "--buildpack gcr.io/paketo-buildpacks/image-labels ",
             shell=True,
             stdout=subprocess.PIPE,
         )

--- a/test/image_builder/test_pack.py
+++ b/test/image_builder/test_pack.py
@@ -163,6 +163,7 @@ class TestPackEnvironment(TestCase):
                 "BP_OCI_VERSION=shorthash",
                 "GIT_BRANCH=feat/tests",
                 "BP_OCI_REF_NAME=ecr/repos",
+                "BP_OCI_SOURCE=https://github.com/org/repo",
             ],
         )
 
@@ -292,6 +293,7 @@ class TestCommand(TestCase):
             "--env BP_OCI_VERSION=shorthash "
             "--env GIT_BRANCH=feat/tests "
             "--env BP_OCI_REF_NAME=ecr/repos "
+            "--env BP_OCI_SOURCE=https://github.com/org/repo "
             "--buildpack fagiani/apt "
             "--buildpack paketo-buildpacks/git "
             "--buildpack paketo-buildpacks/python "
@@ -325,6 +327,7 @@ class TestCommand(TestCase):
             "--env BP_OCI_VERSION=shorthash "
             "--env GIT_BRANCH=feat/tests "
             "--env BP_OCI_REF_NAME=ecr/repos "
+            "--env BP_OCI_SOURCE=https://github.com/org/repo "
             "--buildpack fagiani/apt "
             "--buildpack paketo-buildpacks/git "
             "--buildpack paketo-buildpacks/python "
@@ -359,6 +362,7 @@ class TestCommand(TestCase):
             "--env BP_OCI_VERSION=shorthash "
             "--env GIT_BRANCH=feat/tests "
             "--env BP_OCI_REF_NAME=ecr/repos "
+            "--env BP_OCI_SOURCE=https://github.com/org/repo "
             "--buildpack fagiani/apt "
             "--buildpack paketo-buildpacks/git "
             "--buildpack paketo-buildpacks/python "


### PR DESCRIPTION
- Add a command argument to allow users to build locally without sending notifications.
- Override OCI labels from paketo
    - `org.opencontainers.image.revision` - commit sha
    - `org.opencontainers.image.version` - commit sha
    - `org.opencontainers.image.ref.name` - ecr repo name
- `org.opencontainers.image.source` - add url to git repository
- `uk.gov.trade.digital.build.timestamp` - only used when building remotely