### PR TITLE
DBTP-464 Install copilot and regctl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0
 
-ARG PACK_VERSION
-ARG COPILOT_VERSION
-ARG REGCTL_VERSION
+ARG PACK_VERSION="v0.32.0"
+ARG COPILOT_VERSION="v1.31.0"
+ARG REGCTL_VERSION="v0.5.3"
 
 RUN yum install -y jq
 
@@ -12,12 +12,12 @@ RUN curl -LO https://github.com/buildpacks/pack/releases/download/${PACK_VERSION
     mv pack /usr/bin/
 
 # Install Copilot
-RUN wget -q https://ecs-cli-v2-release.s3.amazonaws.com/copilot-linux-v${COPILOT_VERSION} -O copilot && \
+RUN wget -q https://ecs-cli-v2-release.s3.amazonaws.com/copilot-linux-${COPILOT_VERSION} -O copilot && \
     chmod +x ./copilot && \
     mv copilot /usr/bin/
 
 # Install regclient
-RUN curl -L https://github.com/regclient/regclient/releases/download/v${REGCTL_VERSION}/regctl-linux-amd64 > regctl && \
+RUN curl -L https://github.com/regclient/regclient/releases/download/${REGCTL_VERSION}/regctl-linux-amd64 > regctl && \
     chmod +x ./regctl && \
     mv regctl /usr/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
 FROM public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0
 
 ARG PACK_VERSION
+ARG COPILOT_VERSION
 
 RUN yum install -y jq
 
+# Install Pack
 RUN curl -LO https://github.com/buildpacks/pack/releases/download/${PACK_VERSION}/pack-${PACK_VERSION}-linux.tgz && \
     tar xfz pack-${PACK_VERSION}-linux.tgz && \
     mv pack /usr/bin/
+
+# Install Copilot
+RUN wget -q https://ecs-cli-v2-release.s3.amazonaws.com/copilot-linux-v${COPILOT_VERSION} -O copilot && \
+    chmod +x ./copilot && \
+    mv copilot /usr/bin/
 
 # CAN REMOVE SECTION ONCE OVER TO PYTHON BASED BUILDER
 RUN pip install -U niet

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0
 
 ARG PACK_VERSION
 ARG COPILOT_VERSION
+ARG REGCTL_VERSION
 
 RUN yum install -y jq
 
@@ -14,6 +15,11 @@ RUN curl -LO https://github.com/buildpacks/pack/releases/download/${PACK_VERSION
 RUN wget -q https://ecs-cli-v2-release.s3.amazonaws.com/copilot-linux-v${COPILOT_VERSION} -O copilot && \
     chmod +x ./copilot && \
     mv copilot /usr/bin/
+
+# Install regclient
+RUN curl -L https://github.com/regclient/regclient/releases/download/v${REGCTL_VERSION}/regctl-linux-amd64 > regctl && \
+    chmod +x ./regctl && \
+    mv regctl /usr/bin/
 
 # CAN REMOVE SECTION ONCE OVER TO PYTHON BASED BUILDER
 RUN pip install -U niet


### PR DESCRIPTION
Adding some tools so we can use the ci-image-builder image in our deploy jobs, saving install time.

Adds copilot cli so we don't have to install it as part of the deploy scripts.
Adds regctl as this allows us to show information about the built image without issuing a `docker pull`.