### PR TITLE
DBTP-586 allow setting ecr repo from environment

### DIFF
--- a/image_builder/configuration/codebase.py
+++ b/image_builder/configuration/codebase.py
@@ -39,7 +39,7 @@ def load_codebase_configuration(path) -> CodebaseConfiguration:
         build = CodebaseConfiguration()
         build.builder.name = config["builder"]["name"]
         build.builder.version = config["builder"]["version"]
-        build.repository = config["repository"]
+        build.repository = config["repository"] if "repository" in config else None
 
         if "packs" in config:
             for pack_name in config["packs"]:

--- a/image_builder/pack.py
+++ b/image_builder/pack.py
@@ -128,6 +128,6 @@ class Pack:
             _, _, _, region, account, _, _ = os.environ["CODEBUILD_BUILD_ARN"].split(
                 ":"
             )
-            return f"{account}.dkr.ecr.{region}.amazonaws.com/{self.codebase.build.repository}"
+            return f"{account}.dkr.ecr.{region}.amazonaws.com/{os.getenv('ECR_REPOSITORY', self.codebase.build.repository)}"
 
         return self.codebase.build.repository

--- a/test/fixtures/codebase/missing-repository/.copilot/config.yml
+++ b/test/fixtures/codebase/missing-repository/.copilot/config.yml
@@ -1,0 +1,8 @@
+builder:
+  name: paketobuildpacks/builder-jammy-full
+  version: 0.3.288
+packs:
+  - paketo-buildpacks/python
+  - paketo-buildpacks/nodejs
+packages:
+  - libpq-dev

--- a/test/image_builder/configuration/test_codebase_configuration.py
+++ b/test/image_builder/configuration/test_codebase_configuration.py
@@ -26,6 +26,13 @@ class TestSupportedBuildConfiguration(unittest.TestCase):
         self.assertEqual(config.packs[0].name, "paketo-buildpacks/python")
         self.assertEqual(config.packs[1].name, "paketo-buildpacks/nodejs")
 
+    def test_loading_a_codebase_configuration_without_repository_set(self):
+        config = load_codebase_configuration(
+            self.get_codebase_path("missing-repository")
+        )
+
+        self.assertEqual(config.repository, None)
+
     def test_loading_an_invalid_codebase_configuration(self):
         with pytest.raises(CodebaseConfigurationLoadError):
             load_codebase_configuration(self.get_codebase_path("invalid"))

--- a/test/image_builder/test_pack.py
+++ b/test/image_builder/test_pack.py
@@ -269,6 +269,36 @@ class TestCommand(TestCase):
             "CODEBUILD_BUILD_ARN"
         ] = "arn:aws:codebuild:region:000000000000:build/project:example-build-id"
 
+    def test_get_repository_url_from_config(
+        self,
+        subprocess_popen,
+        load_codebase_revision,
+        load_codebase_processes,
+        load_codebase_languages,
+    ):
+        codebase = Codebase(Path("."))
+        pack = Pack(codebase, "timestamp")
+
+        self.assertEqual(
+            pack.get_repository(), "000000000000.dkr.ecr.region.amazonaws.com/ecr/repos"
+        )
+
+    def test_get_repository_url_from_environment(
+        self,
+        subprocess_popen,
+        load_codebase_revision,
+        load_codebase_processes,
+        load_codebase_languages,
+    ):
+        codebase = Codebase(Path("."))
+        pack = Pack(codebase, "timestamp")
+        os.environ["ECR_REPOSITORY"] = "ecr/environment-repo"
+
+        self.assertEqual(
+            pack.get_repository(),
+            "000000000000.dkr.ecr.region.amazonaws.com/ecr/environment-repo",
+        )
+
     def test_get_command(
         self,
         subprocess_popen,


### PR DESCRIPTION
- Allow overriding the `Pack().get_repository_url()` return value with an environment variable `ECR_REPOSITORY`
- Allow build configurations without `repository` property