### PR TITLE
DBTP-609 - Compact build and deploy notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 .pytest_cache/
 __pycache__/
 .envrc

--- a/image_builder/commands/build.py
+++ b/image_builder/commands/build.py
@@ -1,3 +1,5 @@
+import os
+
 import click
 
 from image_builder.codebase.codebase import Codebase
@@ -22,6 +24,7 @@ def build(publish, send_notifications):
     progress.current_phase_running()
     notify.post_build_progress(progress, codebase)
     pack = Pack(codebase, notify.reference)
+    ecr_repository = os.getenv("ECR_REPOSITORY", codebase.build.repository)
 
     try:
         if not Docker.running():
@@ -38,7 +41,7 @@ def build(publish, send_notifications):
             f"tag={codebase.revision.tag}"
         )
 
-        click.echo(f"Using ECR repository: {codebase.build.repository}")
+        click.echo(f"Using ECR repository: {ecr_repository}")
         click.echo(f"Found processes: {[p.name for p in codebase.processes]}")
         click.echo(f"Found languages: {codebase.languages}")
         click.echo(
@@ -55,7 +58,7 @@ def build(publish, send_notifications):
                 f"*Commit*: {pack.codebase.revision.commit} "
                 f"*Branch*: {pack.codebase.revision.branch} "
                 f"*Tag*: {pack.codebase.revision.tag}",
-                f"*ECR Image*: {pack.codebase.build.repository}:commit-{pack.codebase.revision.commit}",
+                f"*ECR Image*: {ecr_repository}:commit-{pack.codebase.revision.commit}",
                 f"*Processes*: {processes}",
                 f"*Languages*: {pack.codebase.languages}",
                 f"*Builder*: {pack.codebase.build.builder.name}@{pack.codebase.build.builder.version}",

--- a/image_builder/commands/build.py
+++ b/image_builder/commands/build.py
@@ -38,6 +38,7 @@ def build(publish, send_notifications):
             f"tag={codebase.revision.tag}"
         )
 
+        click.echo(f"Using ECR repository: {codebase.build.repository}")
         click.echo(f"Found processes: {[p.name for p in codebase.processes]}")
         click.echo(f"Found languages: {codebase.languages}")
         click.echo(
@@ -50,10 +51,11 @@ def build(publish, send_notifications):
         notify.post_job_comment(
             f"Build: {pack.codebase.revision.get_repository_name()}@{pack.codebase.revision.commit} update",
             [
-                f"*Repository*: {pack.codebase.revision.get_repository_name()}",
+                f"*GitHub Repository*: {pack.codebase.revision.get_repository_name()}",
                 f"*Commit*: {pack.codebase.revision.commit} "
                 f"*Branch*: {pack.codebase.revision.branch} "
                 f"*Tag*: {pack.codebase.revision.tag}",
+                f"*ECR Image*: {pack.codebase.build.repository}:commit-{pack.codebase.revision.commit}",
                 f"*Processes*: {processes}",
                 f"*Languages*: {pack.codebase.languages}",
                 f"*Builder*: {pack.codebase.build.builder.name}@{pack.codebase.build.builder.version}",

--- a/image_builder/commands/deploy.py
+++ b/image_builder/commands/deploy.py
@@ -58,8 +58,8 @@ def deploy(send_notifications):
             f'Deploying {", ".join(copilot_services)} to {copilot_environment}',
             [
                 f'Deploying `{", ".join(copilot_services)}` to `{copilot_environment}` | Commit: '
-                f'<https://github.com/{codebase_repository}/commit/{commit_hash}|{codebase_repository}@{commit_hash}> '
-                f'| <{notify.get_build_url()}|Build Log>',
+                f"<https://github.com/{codebase_repository}/commit/{commit_hash}|{codebase_repository}@{commit_hash}> "
+                f"| <{notify.get_build_url()}|Build Log>",
             ],
             True,
         )
@@ -81,8 +81,8 @@ def deploy(send_notifications):
             f'Deployment of {", ".join(copilot_services)} to {copilot_environment} complete',
             [
                 f'Deployment of `{", ".join(copilot_services)}` to `{copilot_environment}` complete | Commit: '
-                f'<https://github.com/{codebase_repository}/commit/{commit_hash}|{codebase_repository}@{commit_hash}> '
-                f'| <{notify.get_build_url()}|Build Log>',
+                f"<https://github.com/{codebase_repository}/commit/{commit_hash}|{codebase_repository}@{commit_hash}> "
+                f"| <{notify.get_build_url()}|Build Log>",
             ],
             True,
         )

--- a/image_builder/commands/deploy.py
+++ b/image_builder/commands/deploy.py
@@ -51,17 +51,15 @@ def deploy(send_notifications):
 
         copilot_environment = os.getenv("COPILOT_ENVIRONMENT")
         copilot_services = os.getenv("COPILOT_SERVICES", "").split(" ")
-        ecr_repository = os.getenv("ECR_REPOSITORY")
         codebase_repository = os.getenv("CODEBASE_REPOSITORY")
         commit_hash = tag.replace("commit-", "")
 
         notify.post_job_comment(
             f'Deploying {", ".join(copilot_services)} to {copilot_environment}',
             [
-                f'Deploying {", ".join(copilot_services)} to {copilot_environment}',
-                f"*Image*: {ecr_repository}:{tag}",
-                f"*Commit*: <https://github.com/{codebase_repository}/commit/{commit_hash}|{codebase_repository}@{commit_hash}>",
-                f"<{notify.get_build_url()}|Build Log>",
+                f'Deploying `{", ".join(copilot_services)}` to `{copilot_environment}` | Commit: '
+                f'<https://github.com/{codebase_repository}/commit/{commit_hash}|{codebase_repository}@{commit_hash}> '
+                f'| <{notify.get_build_url()}|Build Log>',
             ],
             True,
         )
@@ -82,10 +80,9 @@ def deploy(send_notifications):
         notify.post_job_comment(
             f'Deployment of {", ".join(copilot_services)} to {copilot_environment} complete',
             [
-                f'Deployment of {", ".join(copilot_services)} to {copilot_environment} complete',
-                f"*Image*: {ecr_repository}:{tag}",
-                f"*Commit*: <https://github.com/{codebase_repository}/commit/{commit_hash}|{codebase_repository}@{commit_hash}>",
-                f"<{notify.get_build_url()}|Build Log>",
+                f'Deployment of `{", ".join(copilot_services)}` to `{copilot_environment}` complete | Commit: '
+                f'<https://github.com/{codebase_repository}/commit/{commit_hash}|{codebase_repository}@{commit_hash}> '
+                f'| <{notify.get_build_url()}|Build Log>',
             ],
             True,
         )

--- a/image_builder/notify.py
+++ b/image_builder/notify.py
@@ -46,7 +46,7 @@ class Notify:
                 f"*Revision*: <{codebase.revision.get_repository_url()}/commit/"
                 f"{codebase.revision.commit}|{codebase.revision.commit}>"
             )
-            message_build_logs = f"<{self.get_build_url()}|Build Logs>"
+            message_build_logs = f"*Build Logs*: <{self.get_build_url()}|Build Logs>"
 
             message_blocks = [
                 blocks.SectionBlock(
@@ -56,29 +56,18 @@ class Notify:
                     elements=[
                         blocks.TextObject(type="mrkdwn", text=message_repository),
                         blocks.TextObject(type="mrkdwn", text=message_revision),
-                    ]
-                ),
-                blocks.SectionBlock(
-                    text=blocks.TextObject(
-                        type="mrkdwn", text=f'{progress.get_phase("setup")}'
-                    )
-                ),
-                blocks.SectionBlock(
-                    text=blocks.TextObject(
-                        type="mrkdwn", text=f'{progress.get_phase("build")}'
-                    )
-                ),
-                blocks.SectionBlock(
-                    text=blocks.TextObject(
-                        type="mrkdwn", text=f'{progress.get_phase("publish")}'
-                    )
-                ),
-                blocks.ContextBlock(
-                    elements=[
                         blocks.TextObject(type="mrkdwn", text=message_build_logs),
                     ]
                 ),
+                blocks.ContextBlock(
+                    elements=[
+                        blocks.TextObject(type="mrkdwn", text=f'{progress.get_phase("setup")}'),
+                        blocks.TextObject(type="mrkdwn", text=f'{progress.get_phase("build")}'),
+                        blocks.TextObject(type="mrkdwn", text=f'{progress.get_phase("publish")}'),
+                    ]
+                ),
             ]
+
             if self.reference is None:
                 response = self.slack.chat_postMessage(
                     channel=os.environ["SLACK_CHANNEL_ID"],

--- a/image_builder/notify.py
+++ b/image_builder/notify.py
@@ -61,9 +61,15 @@ class Notify:
                 ),
                 blocks.ContextBlock(
                     elements=[
-                        blocks.TextObject(type="mrkdwn", text=f'{progress.get_phase("setup")}'),
-                        blocks.TextObject(type="mrkdwn", text=f'{progress.get_phase("build")}'),
-                        blocks.TextObject(type="mrkdwn", text=f'{progress.get_phase("publish")}'),
+                        blocks.TextObject(
+                            type="mrkdwn", text=f'{progress.get_phase("setup")}'
+                        ),
+                        blocks.TextObject(
+                            type="mrkdwn", text=f'{progress.get_phase("build")}'
+                        ),
+                        blocks.TextObject(
+                            type="mrkdwn", text=f'{progress.get_phase("publish")}'
+                        ),
                     ]
                 ),
             ]

--- a/image_builder/notify.py
+++ b/image_builder/notify.py
@@ -46,7 +46,7 @@ class Notify:
                 f"*Revision*: <{codebase.revision.get_repository_url()}/commit/"
                 f"{codebase.revision.commit}|{codebase.revision.commit}>"
             )
-            message_build_logs = f"*Build Logs*: <{self.get_build_url()}|Build Logs>"
+            message_build_logs = f"<{self.get_build_url()}|Build Logs>"
 
             message_blocks = [
                 blocks.SectionBlock(

--- a/image_builder/progress.py
+++ b/image_builder/progress.py
@@ -42,9 +42,9 @@ class Phase:
         self.status = PendingStatus()
 
     def __str__(self):
-        output = f"*{self.name}*: {self.status}"
+        output = f"*{self.name.capitalize()}*: {self.status}"
         if self.status.name == "failure" or self.status.name == "success":
-            output += f" - took {round(self.end_time - self.start_time)} seconds"
+            output += f" ({round(self.end_time - self.start_time)} s)"
         return output
 
     def set_status(self, status: Status):

--- a/image_builder/progress.py
+++ b/image_builder/progress.py
@@ -7,7 +7,7 @@ class Status:
     emoji: str
 
     def __str__(self):
-        return f"{self.name} {self.emoji}"
+        return f"{self.name.capitalize()} {self.emoji}"
 
 
 class PendingStatus(Status):

--- a/test/image_builder/commands/test_build.py
+++ b/test/image_builder/commands/test_build.py
@@ -24,6 +24,7 @@ class TestBuildCommand(unittest.TestCase):
         codebase().revision = load_codebase_revision_double(Path("."))
         codebase().processes = load_codebase_processes_double(Path("."))
         codebase().languages = load_codebase_languages_double(Path("."))
+        codebase().build.repository = "ecr/test-repository"
         codebase().build.builder.name = "test-builder"
         codebase().build.builder.version = "0000000"
         pack().get_buildpacks.return_value = [
@@ -48,6 +49,7 @@ class TestBuildCommand(unittest.TestCase):
             "tag=v2.4.6",
             result.output,
         )
+        self.assertIn("Using ECR repository: ecr/test-repository", result.output)
         self.assertIn("Found processes: ['web']", result.output)
         self.assertIn("Found languages: python@3.11, nodejs@20.7", result.output)
         self.assertIn("Using builder: test-builder@0000000", result.output)

--- a/test/image_builder/commands/test_build.py
+++ b/test/image_builder/commands/test_build.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from pathlib import Path
 from test.doubles.codebase import load_codebase_languages_double
@@ -20,11 +21,12 @@ from image_builder.commands.build import build
 class TestBuildCommand(unittest.TestCase):
     @staticmethod
     def setup_mocks(pack, docker, codebase, notify, progress):
+        os.environ["ECR_REPOSITORY"] = "ecr/test-repository"
+
         docker.running.return_value = True
         codebase().revision = load_codebase_revision_double(Path("."))
         codebase().processes = load_codebase_processes_double(Path("."))
         codebase().languages = load_codebase_languages_double(Path("."))
-        codebase().build.repository = "ecr/test-repository"
         codebase().build.builder.name = "test-builder"
         codebase().build.builder.version = "0000000"
         pack().get_buildpacks.return_value = [

--- a/test/image_builder/commands/test_deploy.py
+++ b/test/image_builder/commands/test_deploy.py
@@ -157,9 +157,8 @@ class TestDeployCommand(TestCase):
                 call(
                     "Deploying web, worker to dev",
                     [
-                        "Deploying web, worker to dev",
-                        "*Image*: repository/application:commit-99999",
-                        "*Commit*: <https://github.com/organisation/repository/commit/99999|organisation/repository@99999>",
+                        "Deploying `web, worker` to `dev` | Commit: "
+                        "<https://github.com/organisation/repository/commit/99999|organisation/repository@99999> | "
                         "<https://example.com/build_url|Build Log>",
                     ],
                     True,
@@ -167,9 +166,8 @@ class TestDeployCommand(TestCase):
                 call(
                     "Deployment of web, worker to dev complete",
                     [
-                        "Deployment of web, worker to dev complete",
-                        "*Image*: repository/application:commit-99999",
-                        "*Commit*: <https://github.com/organisation/repository/commit/99999|organisation/repository@99999>",
+                        "Deployment of `web, worker` to `dev` complete | Commit: "
+                        "<https://github.com/organisation/repository/commit/99999|organisation/repository@99999> | "
                         "<https://example.com/build_url|Build Log>",
                     ],
                     True,

--- a/test/image_builder/test_notify.py
+++ b/test/image_builder/test_notify.py
@@ -171,10 +171,10 @@ class TestNotify(unittest.TestCase):
 
 def get_expected_message_blocks(setup="running", build="pending", publish="pending"):
     phase_messages = {
-        "pending": "pending :large_blue_circle:",
-        "running": "running :hourglass_flowing_sand:",
-        "success": "success :large_green_circle: (15 s)",
-        "failure": "failure :red_circle: (15 s)",
+        "pending": "Pending :large_blue_circle:",
+        "running": "Running :hourglass_flowing_sand:",
+        "success": "Success :large_green_circle: (15 s)",
+        "failure": "Failure :red_circle: (15 s)",
     }
 
     return [
@@ -191,7 +191,7 @@ def get_expected_message_blocks(setup="running", build="pending", publish="pendi
                 ),
                 blocks.TextObject(
                     type="mrkdwn",
-                    text=f"*Build Logs*: <https://region.console.aws.amazon.com/codesuite/codebuild/000000000000"
+                    text=f"<https://region.console.aws.amazon.com/codesuite/codebuild/000000000000"
                     f"/projects/project/build/project%3Aexample-build-id|Build Logs>",
                 ),
             ]

--- a/test/image_builder/test_notify.py
+++ b/test/image_builder/test_notify.py
@@ -173,8 +173,8 @@ def get_expected_message_blocks(setup="running", build="pending", publish="pendi
     phase_messages = {
         "pending": "pending :large_blue_circle:",
         "running": "running :hourglass_flowing_sand:",
-        "success": "success :large_green_circle: - took 15 seconds",
-        "failure": "failure :red_circle: - took 15 seconds",
+        "success": "success :large_green_circle: (15 s)",
+        "failure": "failure :red_circle: (15 s)",
     }
 
     return [
@@ -189,22 +189,27 @@ def get_expected_message_blocks(setup="running", build="pending", publish="pendi
                     type="mrkdwn",
                     text=f"*Revision*: <https://github.com/org/repo/commit/commit-sha|commit-sha>",
                 ),
+                blocks.TextObject(
+                    type="mrkdwn",
+                    text=f"*Build Logs*: <https://region.console.aws.amazon.com/codesuite/codebuild/000000000000"
+                         f"/projects/project/build/project%3Aexample-build-id|Build Logs>",
+                ),
             ]
         ),
-        blocks.SectionBlock(
-            text=blocks.TextObject(
-                type="mrkdwn", text=f"*setup*: {phase_messages[setup]}"
-            )
+        blocks.ContextBlock(
+            elements=[
+                blocks.TextObject(
+                    type="mrkdwn",
+                    text=f"*Setup*: {phase_messages[setup]}",
+                ),
+                blocks.TextObject(
+                    type="mrkdwn",
+                    text=f"*Build*: {phase_messages[build]}",
+                ),
+                blocks.TextObject(
+                    type="mrkdwn",
+                    text=f"*Publish*: {phase_messages[publish]}",
+                ),
+            ]
         ),
-        blocks.SectionBlock(
-            text=blocks.TextObject(
-                type="mrkdwn", text=f"*build*: {phase_messages[build]}"
-            )
-        ),
-        blocks.SectionBlock(
-            text=blocks.TextObject(
-                type="mrkdwn", text=f"*publish*: {phase_messages[publish]}"
-            )
-        ),
-        ANY,
     ]

--- a/test/image_builder/test_notify.py
+++ b/test/image_builder/test_notify.py
@@ -192,7 +192,7 @@ def get_expected_message_blocks(setup="running", build="pending", publish="pendi
                 blocks.TextObject(
                     type="mrkdwn",
                     text=f"*Build Logs*: <https://region.console.aws.amazon.com/codesuite/codebuild/000000000000"
-                         f"/projects/project/build/project%3Aexample-build-id|Build Logs>",
+                    f"/projects/project/build/project%3Aexample-build-id|Build Logs>",
                 ),
             ]
         ),


### PR DESCRIPTION
## Context

- Update build and deploy notifications to be compact
  - This removes the ECR image from the deployment notifications, but this has now moved to the build notification which contains all the details.

## Screenshots

### Before

#### Build
<img width="378" alt="image" src="https://github.com/uktrade/ci-image-builder/assets/47318342/136e1c9c-19fa-4559-8859-784f6a347bd9">

#### Deploy
<img width="364" alt="image" src="https://github.com/uktrade/ci-image-builder/assets/47318342/b0afe38a-273f-4a1b-9756-e13ae82a3573">

### After

![image](https://github.com/uktrade/ci-image-builder/assets/47318342/017681a9-330f-40e3-8504-07cfb150af49)

<img width="427" alt="image" src="https://github.com/uktrade/ci-image-builder/assets/47318342/ac773055-234c-4930-904b-bd68d7769458">