### PR TITLE
DBTTP-627 ex dev feedback changes

### DIFF
--- a/image_builder/commands/deploy.py
+++ b/image_builder/commands/deploy.py
@@ -58,7 +58,7 @@ def deploy(send_notifications):
             f'Deploying {", ".join(copilot_services)} to {copilot_environment}',
             [
                 f'Deploying `{", ".join(copilot_services)}` to `{copilot_environment}` | Commit: '
-                f"<https://github.com/{codebase_repository}/commit/{commit_hash}|{codebase_repository}@{commit_hash}> "
+                f"<https://github.com/{codebase_repository}/commit/{commit_hash}|{commit_hash}> "
                 f"| <{notify.get_build_url()}|Build Log>",
             ],
         )
@@ -80,7 +80,7 @@ def deploy(send_notifications):
             f'Deployment of {", ".join(copilot_services)} to {copilot_environment} complete',
             [
                 f'Deployment of `{", ".join(copilot_services)}` to `{copilot_environment}` complete | Commit: '
-                f"<https://github.com/{codebase_repository}/commit/{commit_hash}|{codebase_repository}@{commit_hash}> "
+                f"<https://github.com/{codebase_repository}/commit/{commit_hash}|{commit_hash}> "
                 f"| <{notify.get_build_url()}|Build Log>",
             ],
             True,

--- a/image_builder/commands/deploy.py
+++ b/image_builder/commands/deploy.py
@@ -61,7 +61,6 @@ def deploy(send_notifications):
                 f"<https://github.com/{codebase_repository}/commit/{commit_hash}|{codebase_repository}@{commit_hash}> "
                 f"| <{notify.get_build_url()}|Build Log>",
             ],
-            True,
         )
 
         deploy_command = (

--- a/image_builder/commands/deploy.py
+++ b/image_builder/commands/deploy.py
@@ -66,8 +66,8 @@ def deploy(send_notifications):
         deploy_command = (
             f"copilot deploy --env {copilot_environment} --deploy-env=false --force"
         )
-        for service in copilot_services:
-            deploy_command += f" --name {service}/1"
+        for i, service in enumerate(copilot_services):
+            deploy_command += f" --name {service}/{i + 1}"
 
         result = subprocess.run(
             deploy_command, stdout=subprocess.PIPE, shell=True, cwd=Path("./deploy")

--- a/image_builder/commands/deploy.py
+++ b/image_builder/commands/deploy.py
@@ -55,10 +55,10 @@ def deploy(send_notifications):
         commit_hash = tag.replace("commit-", "")
 
         notify.post_job_comment(
-            f'Deploying {", ".join(copilot_services)} to {copilot_environment}',
+            f"{codebase_repository}@{commit_hash} deploying to {copilot_environment}",
             [
-                f'Deploying `{", ".join(copilot_services)}` to `{copilot_environment}` | Commit: '
-                f"<https://github.com/{codebase_repository}/commit/{commit_hash}|{commit_hash}> "
+                f"<https://github.com/{codebase_repository}/commit/{commit_hash}|"
+                f"{codebase_repository}@{commit_hash}> deploying to `{copilot_environment}` "
                 f"| <{notify.get_build_url()}|Build Log>",
             ],
         )
@@ -77,10 +77,10 @@ def deploy(send_notifications):
             raise DeployError("Failed to deploy")
 
         notify.post_job_comment(
-            f'Deployment of {", ".join(copilot_services)} to {copilot_environment} complete',
+            f"{codebase_repository}@{commit_hash} deployed to {copilot_environment}",
             [
-                f'Deployment of `{", ".join(copilot_services)}` to `{copilot_environment}` complete | Commit: '
-                f"<https://github.com/{codebase_repository}/commit/{commit_hash}|{commit_hash}> "
+                f"<https://github.com/{codebase_repository}/commit/{commit_hash}|"
+                f"{codebase_repository}@{commit_hash}> deployed to `{copilot_environment}` "
                 f"| <{notify.get_build_url()}|Build Log>",
             ],
             True,

--- a/image_builder/configuration/builder_configuration.yml
+++ b/image_builder/configuration/builder_configuration.yml
@@ -1,10 +1,12 @@
 builders:
   - name: paketobuildpacks/builder-jammy-full
     versions:
+      - version: 0.3.317
       - version: 0.3.294
       - version: 0.3.288
   - name: paketobuildpacks/builder-jammy-base
     versions:
+      - version: 0.4.258
       - version: 0.4.240
       - version: 0.4.239
   - name: paketobuildpacks/builder

--- a/test/image_builder/commands/test_deploy.py
+++ b/test/image_builder/commands/test_deploy.py
@@ -155,19 +155,19 @@ class TestDeployCommand(TestCase):
         notify().post_job_comment.assert_has_calls(
             [
                 call(
-                    "Deploying web, worker to dev",
+                    "organisation/repository@99999 deploying to dev",
                     [
-                        "Deploying `web, worker` to `dev` | Commit: "
-                        "<https://github.com/organisation/repository/commit/99999|99999> | "
-                        "<https://example.com/build_url|Build Log>",
+                        "<https://github.com/organisation/repository/commit/99999|organisation/"
+                        "repository@99999> deploying to `dev` | <https://example.com/build_url"
+                        "|Build Log>",
                     ],
                 ),
                 call(
-                    "Deployment of web, worker to dev complete",
+                    "organisation/repository@99999 deployed to dev",
                     [
-                        "Deployment of `web, worker` to `dev` complete | Commit: "
-                        "<https://github.com/organisation/repository/commit/99999|99999> | "
-                        "<https://example.com/build_url|Build Log>",
+                        "<https://github.com/organisation/repository/commit/99999|organisation/"
+                        "repository@99999> deployed to `dev` | <https://example.com/build_url"
+                        "|Build Log>",
                     ],
                     True,
                 ),

--- a/test/image_builder/commands/test_deploy.py
+++ b/test/image_builder/commands/test_deploy.py
@@ -158,7 +158,7 @@ class TestDeployCommand(TestCase):
                     "Deploying web, worker to dev",
                     [
                         "Deploying `web, worker` to `dev` | Commit: "
-                        "<https://github.com/organisation/repository/commit/99999|organisation/repository@99999> | "
+                        "<https://github.com/organisation/repository/commit/99999|99999> | "
                         "<https://example.com/build_url|Build Log>",
                     ],
                 ),
@@ -166,7 +166,7 @@ class TestDeployCommand(TestCase):
                     "Deployment of web, worker to dev complete",
                     [
                         "Deployment of `web, worker` to `dev` complete | Commit: "
-                        "<https://github.com/organisation/repository/commit/99999|organisation/repository@99999> | "
+                        "<https://github.com/organisation/repository/commit/99999|99999> | "
                         "<https://example.com/build_url|Build Log>",
                     ],
                     True,

--- a/test/image_builder/commands/test_deploy.py
+++ b/test/image_builder/commands/test_deploy.py
@@ -161,7 +161,6 @@ class TestDeployCommand(TestCase):
                         "<https://github.com/organisation/repository/commit/99999|organisation/repository@99999> | "
                         "<https://example.com/build_url|Build Log>",
                     ],
-                    True,
                 ),
                 call(
                     "Deployment of web, worker to dev complete",

--- a/test/image_builder/commands/test_deploy.py
+++ b/test/image_builder/commands/test_deploy.py
@@ -143,7 +143,7 @@ class TestDeployCommand(TestCase):
                     shell=True,
                 ),
                 call(
-                    "copilot deploy --env dev --deploy-env=false --force --name web/1 --name worker/1",
+                    "copilot deploy --env dev --deploy-env=false --force --name web/1 --name worker/2",
                     stdout=subprocess.PIPE,
                     shell=True,
                     cwd=Path("deploy"),


### PR DESCRIPTION
- Only share post on thread to channel when deployment complete.
- Much shorter deployment messages.
- Force the deployment order to be in line with ordering in `pipelines.yml` file.
- Add support for the latest jammy builder images.