### PR TITLE
fix: DBTP-763 - Install correct version of copilot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0
 
 ARG PACK_VERSION="v0.32.0"
 ARG REGCTL_VERSION="v0.5.3"
+ARG COPILOT_VERSIONS="1.32.0 1.32.1 1.33.0 1.33.1"
 
 RUN yum install -y jq
 
@@ -9,6 +10,13 @@ RUN yum install -y jq
 RUN curl -LO https://github.com/buildpacks/pack/releases/download/${PACK_VERSION}/pack-${PACK_VERSION}-linux.tgz && \
     tar xfz pack-${PACK_VERSION}-linux.tgz && \
     mv pack /usr/bin/
+
+# Install Copilot
+RUN mkdir /copilot && \
+    for version in ${COPILOT_VERSIONS}; do \
+        wget -q https://ecs-cli-v2-release.s3.amazonaws.com/copilot-linux-v${version} -O /copilot/copilot-${version}; \
+        chmod +x /copilot/copilot-${version}; \
+    done
 
 # Install regclient
 RUN curl -L https://github.com/regclient/regclient/releases/download/${REGCTL_VERSION}/regctl-linux-amd64 > regctl && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0
 
 ARG PACK_VERSION="v0.32.0"
-ARG COPILOT_VERSION="v1.33.1"
 ARG REGCTL_VERSION="v0.5.3"
 
 RUN yum install -y jq
@@ -10,11 +9,6 @@ RUN yum install -y jq
 RUN curl -LO https://github.com/buildpacks/pack/releases/download/${PACK_VERSION}/pack-${PACK_VERSION}-linux.tgz && \
     tar xfz pack-${PACK_VERSION}-linux.tgz && \
     mv pack /usr/bin/
-
-# Install Copilot
-RUN wget -q https://ecs-cli-v2-release.s3.amazonaws.com/copilot-linux-${COPILOT_VERSION} -O copilot && \
-    chmod +x ./copilot && \
-    mv copilot /usr/bin/
 
 # Install regclient
 RUN curl -L https://github.com/regclient/regclient/releases/download/${REGCTL_VERSION}/regctl-linux-amd64 > regctl && \

--- a/image_builder/commands/deploy.py
+++ b/image_builder/commands/deploy.py
@@ -215,7 +215,7 @@ def install_copilot():
         subprocess.run(
             "chmod +x ./copilot && mv copilot /usr/bin/",
             shell=True,
-            check=True
+            check=True,
         )
     except subprocess.CalledProcessError as e:
         raise CannotInstallCopilotDeployError(

--- a/image_builder/commands/deploy.py
+++ b/image_builder/commands/deploy.py
@@ -64,9 +64,7 @@ def deploy(send_notifications):
             ],
         )
 
-        deploy_command = (
-            f"/copilot/./copilot-{copilot_version} deploy --env {copilot_environment} --deploy-env=false --force"
-        )
+        deploy_command = f"/copilot/./copilot-{copilot_version} deploy --env {copilot_environment} --deploy-env=false --force"
         for i, service in enumerate(copilot_services):
             deploy_command += f" --name {service}/{i + 1}"
 

--- a/image_builder/commands/deploy.py
+++ b/image_builder/commands/deploy.py
@@ -199,7 +199,7 @@ def clone_deployment_repository():
 
 def install_copilot():
     try:
-        version = open('deploy/.copilot-version').read()
+        version = open("deploy/.copilot-version").read()
     except FileNotFoundError:
         raise CannotInstallCopilotDeployError(
             "Cannot find .copilot-version file in deploy repository"

--- a/image_builder/commands/deploy.py
+++ b/image_builder/commands/deploy.py
@@ -40,7 +40,7 @@ class CannotInstallCopilotDeployError(DeployError):
 def deploy(send_notifications):
     try:
         clone_deployment_repository()
-        install_copilot()
+        copilot_version = install_copilot()
         tag = get_image_tag_for_deployment()
         os.environ["IMAGE_TAG"] = tag
 
@@ -65,7 +65,7 @@ def deploy(send_notifications):
         )
 
         deploy_command = (
-            f"copilot deploy --env {copilot_environment} --deploy-env=false --force"
+            f"/copilot/./copilot-{copilot_version} deploy --env {copilot_environment} --deploy-env=false --force"
         )
         for i, service in enumerate(copilot_services):
             deploy_command += f" --name {service}/{i + 1}"
@@ -197,7 +197,7 @@ def clone_deployment_repository():
         )
 
 
-def install_copilot():
+def install_copilot() -> str:
     try:
         version = open("deploy/.copilot-version").read().rstrip("\n")
     except FileNotFoundError:
@@ -228,3 +228,5 @@ def install_copilot():
             raise CannotInstallCopilotDeployError(
                 f"Failed to install copilot version {version}: " f"{proc.stderr}"
             )
+
+    return version

--- a/test/image_builder/commands/test_deploy.py
+++ b/test/image_builder/commands/test_deploy.py
@@ -25,10 +25,12 @@ COMMAND_PATTERNS = {
         )
     ),
     "git clone": StubbedProcess(returncode=0),
-    "copilot deploy": StubbedProcess(returncode=0),
     "wget": StubbedProcess(returncode=0),
     "chmod": StubbedProcess(returncode=0),
-    "/copilot": StubbedProcess(returncode=0),
+    "/copilot/./copilot-1.33.1 deploy": StubbedProcess(returncode=0),
+    "/copilot/./copilot-1.31.1 --version": StubbedProcess(returncode=0),
+    "/copilot/./copilot-1.31.0 --version": StubbedProcess(returncode=1),
+    "/copilot/./copilot-test --version": StubbedProcess(returncode=1),
 }
 
 
@@ -155,7 +157,7 @@ class TestDeployCommand(BaseTestCase):
                     shell=True,
                 ),
                 call(
-                    "copilot deploy --env dev --deploy-env=false --force --name web/1 --name worker/2",
+                    "/copilot/./copilot-1.33.1 deploy --env dev --deploy-env=false --force --name web/1 --name worker/2",
                     stdout=subprocess.PIPE,
                     shell=True,
                     cwd=Path("deploy"),
@@ -383,7 +385,7 @@ class TestDeployCommand(BaseTestCase):
         self.setup_environment()
         self.fs.remove_object("deploy/.copilot-version")
         self.fs.create_file("deploy/.copilot-version", contents="test")
-        COMMAND_PATTERNS["/copilot"] = StubbedProcess(returncode=1)
+        COMMAND_PATTERNS["/copilot/./copilot-test --version"] = StubbedProcess(returncode=1)
         COMMAND_PATTERNS["wget"] = StubbedProcess(returncode=1)
 
         result = self.run_deploy()
@@ -395,7 +397,6 @@ class TestDeployCommand(BaseTestCase):
 
         self.assertEqual(result.exit_code, 1)
         self.teardown_environment()
-        COMMAND_PATTERNS["/copilot"] = StubbedProcess(returncode=0)
         COMMAND_PATTERNS["wget"] = StubbedProcess(returncode=0)
 
     def test_installing_copilot_succeeds_when_preinstalled_version_does_not_exist(
@@ -405,7 +406,7 @@ class TestDeployCommand(BaseTestCase):
         self.setup_environment()
         self.fs.remove_object("deploy/.copilot-version")
         self.fs.create_file("deploy/.copilot-version", contents="1.31.0")
-        COMMAND_PATTERNS["/copilot"] = StubbedProcess(returncode=1)
+        COMMAND_PATTERNS["/copilot/./copilot-1.31.0 --version"] = StubbedProcess(returncode=1)
 
         result = self.run_deploy()
 
@@ -416,4 +417,3 @@ class TestDeployCommand(BaseTestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.teardown_environment()
-        COMMAND_PATTERNS["/copilot"] = StubbedProcess(returncode=0)

--- a/test/image_builder/commands/test_deploy.py
+++ b/test/image_builder/commands/test_deploy.py
@@ -362,3 +362,20 @@ class TestDeployCommand(BaseTestCase):
             self.teardown_environment()
         finally:
             COMMAND_PATTERNS["regctl"] = old_regctl
+
+    def test_installing_copilot_fails_when_no_version_file_present(
+        self, docker, notify, subprocess_run, subprocess_popen
+    ):
+        self.setup_mocks(docker, notify, subprocess_run, subprocess_popen)
+        self.setup_environment()
+        self.fs.remove_object('deploy/.copilot-version')
+
+        result = self.run_deploy()
+
+        self.assertIn(
+            "CannotInstallCopilotDeployError: Cannot find .copilot-version file in deploy repository",
+            result.output,
+        )
+
+        self.assertEqual(result.exit_code, 1)
+        self.teardown_environment()

--- a/test/image_builder/commands/test_deploy.py
+++ b/test/image_builder/commands/test_deploy.py
@@ -31,7 +31,9 @@ COMMAND_PATTERNS = {
 }
 
 
-def call_subprocess_run(command: str, stdout=subprocess.PIPE, shell=True, check=True, cwd="."):
+def call_subprocess_run(
+    command: str, stdout=subprocess.PIPE, shell=True, check=True, cwd="."
+):
     for pattern in COMMAND_PATTERNS.keys():
         if command.startswith(pattern):
             return COMMAND_PATTERNS[pattern]
@@ -48,10 +50,7 @@ class TestDeployCommand(BaseTestCase):
         super().setUp()
         self.setUpPyfakefs()
         self.fs.create_dir("/src")
-        self.fs.create_file(
-            "deploy/.copilot-version",
-            contents="1.33.1"
-        )
+        self.fs.create_file("deploy/.copilot-version", contents="1.33.1")
 
     @staticmethod
     def setup_mocks(docker, notify, subprocess_run, subprocess_popen):
@@ -368,7 +367,7 @@ class TestDeployCommand(BaseTestCase):
     ):
         self.setup_mocks(docker, notify, subprocess_run, subprocess_popen)
         self.setup_environment()
-        self.fs.remove_object('deploy/.copilot-version')
+        self.fs.remove_object("deploy/.copilot-version")
 
         result = self.run_deploy()
 


### PR DESCRIPTION
[DBTP-763](https://uktrade.atlassian.net/browse/DBTP-763) & [DBTP-783](https://uktrade.atlassian.net/browse/DBTP-783)
- Remove pre-installed copilot version from image
- Pre-download recent copilot versions to speed up deployments
- Use correct pre-installed version or install the correct version of copilot when deploying services

[DBTP-763]: https://uktrade.atlassian.net/browse/DBTP-763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DBTP-783]: https://uktrade.atlassian.net/browse/DBTP-783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ