### PR TITLE
fix: only add apt buildpack if packages in config

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -15,7 +15,7 @@ jobs:
     needs: [versions]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '${{ needs.versions.outputs.python-version }}'
           cache: 'pip'
@@ -27,7 +27,7 @@ jobs:
     needs: [versions]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '${{ needs.versions.outputs.python-version }}'
           cache: 'pip'

--- a/image_builder/codebase/codebase.py
+++ b/image_builder/codebase/codebase.py
@@ -58,8 +58,9 @@ class Codebase:
         )
         self.original_files["delete"]["buildpack-run.sh"] = None
 
-        self.path.joinpath("Aptfile").write_text("\n".join(self.build.packages))
-        self.original_files["delete"]["Aptfile"] = None
+        if self.build.packages:
+            self.path.joinpath("Aptfile").write_text("\n".join(self.build.packages))
+            self.original_files["delete"]["Aptfile"] = None
 
     def teardown(self):
         for filename, contents in self.original_files["write"].items():

--- a/image_builder/configuration/builder_configuration.yml
+++ b/image_builder/configuration/builder_configuration.yml
@@ -1,11 +1,13 @@
 builders:
   - name: paketobuildpacks/builder-jammy-full
     versions:
+      - version: 0.3.338
       - version: 0.3.317
       - version: 0.3.294
       - version: 0.3.288
   - name: paketobuildpacks/builder-jammy-base
     versions:
+      - version: 0.4.278
       - version: 0.4.258
       - version: 0.4.240
       - version: 0.4.239

--- a/image_builder/pack.py
+++ b/image_builder/pack.py
@@ -53,7 +53,10 @@ class Pack:
         return command
 
     def get_buildpacks(self):
-        buildpacks = ["fagiani/apt", "paketo-buildpacks/git"]
+        buildpacks = ["paketo-buildpacks/git"]
+
+        if self.codebase.build.packages:
+            buildpacks.append("fagiani/apt")
 
         for pack in self.codebase.build.packs:
             buildpacks.append(pack.name)

--- a/test/image_builder/test_pack.py
+++ b/test/image_builder/test_pack.py
@@ -59,8 +59,7 @@ class TestPackBuildpacks(BaseTestCase):
                         "version": "0.3.288",
                     },
                     "packs": [
-                        "paketo-buildpacks/python",
-                        "paketo-buildpacks/nodejs",
+                        "paketo-buildpacks/nginx",
                     ],
                 }
             ),
@@ -72,8 +71,8 @@ class TestPackBuildpacks(BaseTestCase):
         self.assertEqual(
             pack.get_buildpacks(),
             [
-                "fagiani/apt",
                 "paketo-buildpacks/git",
+                "paketo-buildpacks/nginx",
                 "paketo-buildpacks/python",
                 "paketo-buildpacks/nodejs",
                 "fagiani/run",
@@ -105,8 +104,43 @@ class TestPackBuildpacks(BaseTestCase):
         self.assertEqual(
             pack.get_buildpacks(),
             [
-                "fagiani/apt",
                 "paketo-buildpacks/git",
+                "paketo-buildpacks/python",
+                "paketo-buildpacks/nodejs",
+                "fagiani/run",
+                "gcr.io/paketo-buildpacks/image-labels",
+                "gcr.io/paketo-buildpacks/environment-variables",
+            ],
+        )
+
+    def test_buildpacks_when_packages_present_in_config(
+        self, load_codebase_revision, load_codebase_processes, load_codebase_languages
+    ):
+        self.fs.create_dir(".copilot")
+        self.fs.create_file(
+            ".copilot/config.yml",
+            contents=dump(
+                {
+                    "repository": "ecr/repos",
+                    "builder": {
+                        "name": "paketobuildpacks/builder-jammy-full",
+                        "version": "0.3.288",
+                    },
+                    "packages": [
+                        "graphviz",
+                    ],
+                }
+            ),
+        )
+
+        codebase = Codebase(Path("."))
+        pack = Pack(codebase)
+
+        self.assertEqual(
+            pack.get_buildpacks(),
+            [
+                "paketo-buildpacks/git",
+                "fagiani/apt",
                 "paketo-buildpacks/python",
                 "paketo-buildpacks/nodejs",
                 "fagiani/run",
@@ -400,7 +434,6 @@ class TestCommand(BaseTestCase):
             "--env BP_OCI_REF_NAME=tag-v2.4.6 "
             "--env BP_OCI_SOURCE=https://github.com/org/repo "
             '--env BP_IMAGE_LABELS="uk.gov.trade.digital.build.timestamp=timestamp" '
-            "--buildpack fagiani/apt "
             "--buildpack paketo-buildpacks/git "
             "--buildpack paketo-buildpacks/python "
             "--buildpack paketo-buildpacks/nodejs "
@@ -437,7 +470,6 @@ class TestCommand(BaseTestCase):
             "--env BP_OCI_REF_NAME=tag-v2.4.6 "
             "--env BP_OCI_SOURCE=https://github.com/org/repo "
             '--env BP_IMAGE_LABELS="uk.gov.trade.digital.build.timestamp=timestamp" '
-            "--buildpack fagiani/apt "
             "--buildpack paketo-buildpacks/git "
             "--buildpack paketo-buildpacks/python "
             "--buildpack paketo-buildpacks/nodejs "
@@ -476,7 +508,6 @@ class TestCommand(BaseTestCase):
             "--env BP_OCI_REF_NAME=tag-v2.4.6 "
             "--env BP_OCI_SOURCE=https://github.com/org/repo "
             '--env BP_IMAGE_LABELS="uk.gov.trade.digital.build.timestamp=timestamp" '
-            "--buildpack fagiani/apt "
             "--buildpack paketo-buildpacks/git "
             "--buildpack paketo-buildpacks/python "
             "--buildpack paketo-buildpacks/nodejs "


### PR DESCRIPTION
The apt buildpack is only compatible with buildpack API version `0.4` whereas the buildpack for python `3.12` depends on a builder version that only supports buildpack API version `0.7` and above. To work around this for the moment, we only add the apt buildpack if explicitly configuring a list of packages to install.