### PR TITLE
chore: bump slack sdk to 3.27.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ python = "^3.11"
 PyYaml = "^6.0.1"
 requests = "^2.31.0"
 click = "^8.1.7"
-slack-sdk = "^3.23.0"
+slack-sdk = "^3.27.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ pyfakefs==5.3.0
 requests==2.31.0
 click==8.1.7
 pytest-cov==4.1.0
-slack-sdk==3.23.0
+slack-sdk==3.27.1
 pre-commit==3.5.0


### PR DESCRIPTION
bump slack sdk to 3.27.1