### PR TITLE
Output stderr from pack command in exception

### DIFF
--- a/image_builder/pack.py
+++ b/image_builder/pack.py
@@ -25,7 +25,11 @@ class Pack:
         self, publish=False, on_building: Callable = None, on_exporting: Callable = None
     ):
         proc = subprocess.Popen(
-            self.get_command(publish), shell=True, stdout=subprocess.PIPE, text=True
+            self.get_command(publish),
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
         )
 
         while proc.poll() is None:
@@ -37,7 +41,7 @@ class Pack:
                 on_exporting()
 
         if proc.returncode != 0:
-            raise PackCommandFailedError
+            raise PackCommandFailedError(proc.stderr.read())
 
         if publish and self.codebase.build.additional_repository:
             publish_to_additional_repository(

--- a/test/image_builder/test_pack.py
+++ b/test/image_builder/test_pack.py
@@ -490,6 +490,7 @@ class TestCommand(BaseTestCase):
             " ".join(self.expected_command),
             shell=True,
             stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
         )
 
@@ -518,7 +519,11 @@ class TestCommand(BaseTestCase):
 
         expected = " ".join(self.expected_command + [self.publish_opts])
         subprocess_popen.assert_called_with(
-            expected, shell=True, stdout=subprocess.PIPE, text=True
+            expected,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
         )
 
         publish_to_additional.assert_called_with(
@@ -541,7 +546,11 @@ class TestCommand(BaseTestCase):
 
         expected = " ".join(self.expected_command)
         subprocess_popen.assert_called_with(
-            expected, shell=True, stdout=subprocess.PIPE, text=True
+            expected,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
         )
 
         publish_to_additional.assert_not_called()


### PR DESCRIPTION
When we raise a `PackCommandFailedError` include the contents of `stderr` in the output and notification.