### PR TITLE
fix: truncate to only show last 2500 characters of error

### DIFF
--- a/image_builder/pack.py
+++ b/image_builder/pack.py
@@ -41,7 +41,11 @@ class Pack:
                 on_exporting()
 
         if proc.returncode != 0:
-            raise PackCommandFailedError(proc.stderr.read())
+            error = proc.stderr.read().decode("utf-8")
+            print(len(error), len(error) - 2500)
+            raise PackCommandFailedError(
+                error[len(error) - 2500 :] if len(error) > 2500 else error
+            )
 
         if publish and self.codebase.build.additional_repository:
             publish_to_additional_repository(

--- a/test/doubles/fake_pack_fail.sh
+++ b/test/doubles/fake_pack_fail.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+echo "Running fake pack command"
+echo "===> BUILDING"
+echo "."
+echo "."
+echo "."
+echo "."
+echo "."
+echo "."
+>&2 echo "Not in notification"
+>&2 awk 'BEGIN {s = sprintf("%*s", 3000, ""); gsub(".", "x", s); print s; }'
+>&2 echo "Failed to build"
+exit 127


### PR DESCRIPTION
this is due to a maximum of 3000 chars in a slack notification additional prefixing of the error message means 2500 characters is a safe option to use