### PR TITLE
Add AWS Copilot 1.33.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:5.0
 
 ARG PACK_VERSION="v0.32.0"
 ARG REGCTL_VERSION="v0.5.3"
-ARG COPILOT_VERSIONS="1.32.0 1.32.1 1.33.0 1.33.1 1.33.2 1.33.3"
+ARG COPILOT_VERSIONS="1.32.0 1.32.1 1.33.0 1.33.1 1.33.2 1.33.3 1.33.4"
 
 RUN yum install -y jq
 


### PR DESCRIPTION
So it's preinstalled to speed up builds.