### PR TITLE
DBTP-1327 Add builder-jammy-full 0.3.397 & install dependencies for all Pythons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,19 @@ COPY builder-post.sh /work/builder-post.sh
 # CAN REMOVE SECTION ONCE OVER TO PYTHON BASED BUILDER
 
 COPY ./requirements.txt /work/
-RUN pyenv versions && python --version
-RUN cd /work && pip install -r requirements.txt
+
+# So we can easily see what versions of Python it has installed
+RUN pyenv versions
+
+# Install dependencies for all Python versions so that it
+# doesn't matter which is used to send Slack notifications
+RUN cd /work && \
+    while IFS= read -r line; do \
+        pyenv local "${line}" \
+        python --version \
+        pip install -r requirements.txt \
+        pyenv local --unset \
+    done <<< "$(pyenv versions --bare)"
 
 COPY ./image_builder /work/image_builder
 COPY cli /work/

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN pyenv versions
 # doesn't matter which is used to send Slack notifications
 RUN cd /work && \
     pyenv versions --bare | while IFS= read -r line; do \
-        pyenv local "${line}" \
+        pyenv local "$line" \
         python --version \
         pip install -r requirements.txt \
         pyenv local --unset \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,12 +43,12 @@ RUN pyenv versions
 # Install dependencies for all Python versions so that it
 # doesn't matter which is used to send Slack notifications
 RUN cd /work && \
-    while IFS= read -r line; do \
+    pyenv versions --bare | while IFS= read -r line; do \
         pyenv local "${line}" \
         python --version \
         pip install -r requirements.txt \
         pyenv local --unset \
-    done <<< "$(pyenv versions --bare)"
+    done
 
 COPY ./image_builder /work/image_builder
 COPY cli /work/

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ COPY builder-post.sh /work/builder-post.sh
 # CAN REMOVE SECTION ONCE OVER TO PYTHON BASED BUILDER
 
 COPY ./requirements.txt /work/
+RUN pyenv versions && python --version
 RUN cd /work && pip install -r requirements.txt
 
 COPY ./image_builder /work/image_builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,14 +42,9 @@ RUN pyenv versions
 
 # Install dependencies for all Python versions so that it
 # doesn't matter which is used to send Slack notifications
-RUN cd /work && \
-    pyenv versions --bare | while IFS= read -r line; do \
-        pyenv local "$line" \
-        python --version \
-        pip install -r requirements.txt \
-        pyenv local --unset \
-    done
-
+COPY ./install-dependencies-for-all-pythons.sh /work/
+RUN cd /work && ./install-dependencies-for-all-pythons.sh
+RUN rm /work/install-dependencies-for-all-pythons.sh
 RUN exit 1
 
 COPY ./image_builder /work/image_builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,11 +37,12 @@ COPY builder-post.sh /work/builder-post.sh
 
 COPY ./requirements.txt /work/
 
-# So we can easily see what versions of Python it has installed
+# So we can easily see what versions of Python were installed
+# during the build.
 RUN pyenv versions
 
-# Install dependencies for all Python versions so that it
-# doesn't matter which is used to send Slack notifications
+# Install dependencies for all Python versions so that it doesn't
+# matter which is used to send Slack notifications.
 COPY ./install-dependencies-for-all-pythons.sh /work/
 RUN cd /work && \
     ./install-dependencies-for-all-pythons.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,36 +4,36 @@ ARG PACK_VERSION="v0.32.0"
 ARG REGCTL_VERSION="v0.5.3"
 ARG COPILOT_VERSIONS="1.32.0 1.32.1 1.33.0 1.33.1 1.33.2 1.33.3 1.33.4 1.34.0"
 
-#RUN yum install -y jq
-#
-## Install Pack
-#RUN curl -LO https://github.com/buildpacks/pack/releases/download/${PACK_VERSION}/pack-${PACK_VERSION}-linux.tgz && \
-#    tar xfz pack-${PACK_VERSION}-linux.tgz && \
-#    mv pack /usr/bin/
-#
-## Install Copilot
-#RUN mkdir /copilot && \
-#    for version in ${COPILOT_VERSIONS}; do \
-#        wget -q https://ecs-cli-v2-release.s3.amazonaws.com/copilot-linux-v${version} -O /copilot/copilot-${version}; \
-#        chmod +x /copilot/copilot-${version}; \
-#    done
-#
-## Install regclient
-#RUN curl -L https://github.com/regclient/regclient/releases/download/${REGCTL_VERSION}/regctl-linux-amd64 > regctl && \
-#    chmod +x ./regctl && \
-#    mv regctl /usr/bin/
-#
-## CAN REMOVE SECTION ONCE OVER TO PYTHON BASED BUILDER
-#RUN pip install -U niet
-#
-#RUN mkdir /work
-#RUN mkdir /docker_images
-#
-#COPY build.sh /work/build.sh
-#RUN chmod +x /work/build.sh
-#
-#COPY builder-post.sh /work/builder-post.sh
-## CAN REMOVE SECTION ONCE OVER TO PYTHON BASED BUILDER
+RUN yum install -y jq
+
+# Install Pack
+RUN curl -LO https://github.com/buildpacks/pack/releases/download/${PACK_VERSION}/pack-${PACK_VERSION}-linux.tgz && \
+    tar xfz pack-${PACK_VERSION}-linux.tgz && \
+    mv pack /usr/bin/
+
+# Install Copilot
+RUN mkdir /copilot && \
+    for version in ${COPILOT_VERSIONS}; do \
+        wget -q https://ecs-cli-v2-release.s3.amazonaws.com/copilot-linux-v${version} -O /copilot/copilot-${version}; \
+        chmod +x /copilot/copilot-${version}; \
+    done
+
+# Install regclient
+RUN curl -L https://github.com/regclient/regclient/releases/download/${REGCTL_VERSION}/regctl-linux-amd64 > regctl && \
+    chmod +x ./regctl && \
+    mv regctl /usr/bin/
+
+# CAN REMOVE SECTION ONCE OVER TO PYTHON BASED BUILDER
+RUN pip install -U niet
+
+RUN mkdir /work
+RUN mkdir /docker_images
+
+COPY build.sh /work/build.sh
+RUN chmod +x /work/build.sh
+
+COPY builder-post.sh /work/builder-post.sh
+# CAN REMOVE SECTION ONCE OVER TO PYTHON BASED BUILDER
 
 COPY ./requirements.txt /work/
 
@@ -43,9 +43,9 @@ RUN pyenv versions
 # Install dependencies for all Python versions so that it
 # doesn't matter which is used to send Slack notifications
 COPY ./install-dependencies-for-all-pythons.sh /work/
-RUN cd /work && ./install-dependencies-for-all-pythons.sh
-RUN rm /work/install-dependencies-for-all-pythons.sh
-RUN exit 1
+RUN cd /work && \
+    ./install-dependencies-for-all-pythons.sh && \
+    rm /work/install-dependencies-for-all-pythons.sh
 
 COPY ./image_builder /work/image_builder
 COPY cli /work/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,36 +4,36 @@ ARG PACK_VERSION="v0.32.0"
 ARG REGCTL_VERSION="v0.5.3"
 ARG COPILOT_VERSIONS="1.32.0 1.32.1 1.33.0 1.33.1 1.33.2 1.33.3 1.33.4 1.34.0"
 
-RUN yum install -y jq
-
-# Install Pack
-RUN curl -LO https://github.com/buildpacks/pack/releases/download/${PACK_VERSION}/pack-${PACK_VERSION}-linux.tgz && \
-    tar xfz pack-${PACK_VERSION}-linux.tgz && \
-    mv pack /usr/bin/
-
-# Install Copilot
-RUN mkdir /copilot && \
-    for version in ${COPILOT_VERSIONS}; do \
-        wget -q https://ecs-cli-v2-release.s3.amazonaws.com/copilot-linux-v${version} -O /copilot/copilot-${version}; \
-        chmod +x /copilot/copilot-${version}; \
-    done
-
-# Install regclient
-RUN curl -L https://github.com/regclient/regclient/releases/download/${REGCTL_VERSION}/regctl-linux-amd64 > regctl && \
-    chmod +x ./regctl && \
-    mv regctl /usr/bin/
-
-# CAN REMOVE SECTION ONCE OVER TO PYTHON BASED BUILDER
-RUN pip install -U niet
-
-RUN mkdir /work
-RUN mkdir /docker_images
-
-COPY build.sh /work/build.sh
-RUN chmod +x /work/build.sh
-
-COPY builder-post.sh /work/builder-post.sh
-# CAN REMOVE SECTION ONCE OVER TO PYTHON BASED BUILDER
+#RUN yum install -y jq
+#
+## Install Pack
+#RUN curl -LO https://github.com/buildpacks/pack/releases/download/${PACK_VERSION}/pack-${PACK_VERSION}-linux.tgz && \
+#    tar xfz pack-${PACK_VERSION}-linux.tgz && \
+#    mv pack /usr/bin/
+#
+## Install Copilot
+#RUN mkdir /copilot && \
+#    for version in ${COPILOT_VERSIONS}; do \
+#        wget -q https://ecs-cli-v2-release.s3.amazonaws.com/copilot-linux-v${version} -O /copilot/copilot-${version}; \
+#        chmod +x /copilot/copilot-${version}; \
+#    done
+#
+## Install regclient
+#RUN curl -L https://github.com/regclient/regclient/releases/download/${REGCTL_VERSION}/regctl-linux-amd64 > regctl && \
+#    chmod +x ./regctl && \
+#    mv regctl /usr/bin/
+#
+## CAN REMOVE SECTION ONCE OVER TO PYTHON BASED BUILDER
+#RUN pip install -U niet
+#
+#RUN mkdir /work
+#RUN mkdir /docker_images
+#
+#COPY build.sh /work/build.sh
+#RUN chmod +x /work/build.sh
+#
+#COPY builder-post.sh /work/builder-post.sh
+## CAN REMOVE SECTION ONCE OVER TO PYTHON BASED BUILDER
 
 COPY ./requirements.txt /work/
 
@@ -49,6 +49,8 @@ RUN cd /work && \
         pip install -r requirements.txt \
         pyenv local --unset \
     done
+
+RUN exit 1
 
 COPY ./image_builder /work/image_builder
 COPY cli /work/

--- a/image_builder/configuration/builder_configuration.yml
+++ b/image_builder/configuration/builder_configuration.yml
@@ -1,6 +1,7 @@
 builders:
   - name: paketobuildpacks/builder-jammy-full
     versions:
+      - version: 0.3.397
       - version: 0.3.339
       - version: 0.3.338
       - version: 0.3.317

--- a/install-dependencies-for-all-pythons.sh
+++ b/install-dependencies-for-all-pythons.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+while IFS= read -r line; do
+    pyenv local "$line"
+    python --version
+    pip install -r requirements.txt
+    pyenv local --unset
+done <<< "$(pyenv versions --bare)"


### PR DESCRIPTION
Motivated by a desire to support the latest Python release, 3.12.5 I added the latest builder-jammy-full.

Then @james-francis-MT and I discovered that the versions of Python we were trying to use in our respective codebases where not installed on this image. Workaround for that was for me to go down one patch number and @james-francis-MT to go up one.

Next problem was when it tried to send the Slack notification using Python 3.12. Turn out the Slack SDK was installed under Python 3.11 and not available when the command was called using Python 3.12.

I've added a script to install the dependencies for all installed Python versions when the image is built, so that they are available to be used as required at runtime. This adds about 15MB, but to a 4GB image, so insignificant.