### PR TITLE
Make tagging conform to our standard approach more closely

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,4 +136,13 @@ Build the image:
 
 ## Publishing `ci-image-builder`
 
-TODO
+When you push a commit to GitHub, a CodeBuild job will attempt to build the image and publish it with the following tags intended to allow for testing etc.
+
+- `branch-<branch_name>`
+- `commit-<commit_hash>`
+- `pack-<pack_version>`
+
+When you tag a commit to release it, the following tags should be added
+
+- `tag-<commit_tag>`
+- `tag-latest` (if the image has a semantic versioning tag like `1.2.3`)

--- a/README.md
+++ b/README.md
@@ -133,3 +133,7 @@ Build the image:
 ```shell
 ../ci-image-builder/cli build
 ```
+
+## Publishing `ci-image-builder`
+
+TODO

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -34,16 +34,15 @@ phases:
           TAG_LATEST="tag-latest";
         fi
       fi
-    - >
-      TEST_TAG="0.0.0"
-      REGEX='^([0-9]+\.){2}[0-9]+$'
-      if [[ $TEST_TAG =~ $REGEX ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
-      TEST_TAG="0.0.0"
-      if [[ $TEST_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
-      TEST_TAG="000.000.000"
-      if [[ $TEST_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
-      TEST_TAG="a.b.c"
-      if [[ $TEST_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
+    - TEST_TAG="0.0.0"
+    - REGEX='^([0-9]+\.){2}[0-9]+$'
+    - if [[ $TEST_TAG =~ $REGEX ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
+    - TEST_TAG="0.0.0"
+    - if [[ $TEST_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
+    - TEST_TAG="000.000.000"
+    - if [[ $TEST_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
+    - TEST_TAG="a.b.c"
+    - if [[ $TEST_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
     - > 
       echo "COMMIT_TAG: $COMMIT_TAG"
       echo -e "\nBRANCH_TAG: $BRANCH_TAG"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -48,7 +48,7 @@ phases:
     - >
       if [ $TAG_TAG != "" ]; then
         docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$TAG_TAG";
-        if [[ $TAG_TAG =~ ^(\d+\.\d+\.\d+)$ ]]; then
+        if [[ $TAG_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then
           docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:tag-latest";
         fi
       fi

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -17,17 +17,39 @@ phases:
     - aws --version
     - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/uktrade
     - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
-    - IMAGE_TAG=${COMMIT_HASH:=latest}
+    - COMMIT_TAG="commit-$COMMIT_HASH"
+    - PACK_VERSION_TAG="pack-$PACK_VERSION"
     - REPOSITORY_URI=public.ecr.aws/uktrade/ci-image-builder
-    - if [ -z $CODEBUILD_WEBHOOK_TRIGGER ]; then GIT_BRANCH=$(git branch --show-current); else GIT_BRANCH=$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}'); fi
+    - >
+      if [ -z $CODEBUILD_WEBHOOK_TRIGGER ]; then
+        BRANCH_TAG="branch-$(git branch --show-current)";
+      elif [[ $CODEBUILD_WEBHOOK_TRIGGER == branch/*]]; then
+        BRANCH_TAG="branch_$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}')";
+      fi
+    - >
+      if [[ $CODEBUILD_WEBHOOK_TRIGGER == tag/*]]; then
+        TAG_TAG=$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}');
+      fi
+    - > 
+      echo "COMMIT_TAG: $COMMIT_TAG"
+      echo "BRANCH_TAG: $BRANCH_TAG"
+      echo "TAG_TAG: $TAG_TAG"
+      echo "PACK_VERSION_TAG: $PACK_VERSION_TAG"
   build:
     commands:
     - echo Build started on `date`
     - echo Building the Docker image...
     - docker build --build-arg PACK_VERSION=${PACK_VERSION} -t $REPOSITORY_URI .
-    - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
-    - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$GIT_BRANCH
-    - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$PACK_VERSION
+    - docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$COMMIT_TAG"
+    - >
+      if [ -z $BRANCH_TAG ]; then
+        docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$BRANCH_TAG";
+      fi
+    - >
+      if [ -z $TAG_TAG ]; then
+        docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$TAG_TAG";
+      fi
+    - docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$PACK_VERSION_TAG"
 
   post_build:
     commands:
@@ -35,7 +57,7 @@ phases:
     - echo pushing to repo
     - docker push -a $REPOSITORY_URI
     - echo Writing image definitions file...
-    - printf '{"ImageURI":"%s"}' $REPOSITORY_URI:$IMAGE_TAG > imageDetail.json
+    - printf '{"ImageURI":"%s"}' $REPOSITORY_URI:$COMMIT_TAG > imageDetail.json
 artifacts:
   files:
     - imageDetail.json

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -54,7 +54,7 @@ phases:
     - >
       if [ $TAG_TAG != "" ]; then
         docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$TAG_TAG";
-        if [ $TAG_LATEST != ""]; then
+        if [ $TAG_LATEST != "" ]; then
           docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$TAG_LATEST";
         fi
       fi

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -48,6 +48,9 @@ phases:
     - >
       if [ -n $TAG_TAG ]; then
         docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$TAG_TAG";
+        if [[ $TAG_TAG =~ ^(\d+\.\d+\.\d+)$ ]]; then
+          docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:tag-latest";
+        fi
       fi
     - docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$PACK_VERSION_TAG"
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -32,9 +32,9 @@ phases:
       fi
     - > 
       echo "COMMIT_TAG: $COMMIT_TAG"
-      echo "BRANCH_TAG: $BRANCH_TAG"
-      echo "TAG_TAG: $TAG_TAG"
-      echo "PACK_VERSION_TAG: $PACK_VERSION_TAG"
+      echo -e "\nBRANCH_TAG: $BRANCH_TAG"
+      echo -e "\nTAG_TAG: $TAG_TAG"
+      echo -e "\nPACK_VERSION_TAG: $PACK_VERSION_TAG"
   build:
     commands:
     - echo Build started on `date`

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -30,8 +30,6 @@ phases:
       if [[ $CODEBUILD_WEBHOOK_TRIGGER == tag/* ]]; then
         INCOMING_TAG=$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}');
         TAG_TAG="tag-$INCOMING_TAG";
-        # So it doesn't lose the "commit-*" tag from the image built from the untagged commit and lose our audit trail
-        COMMIT_TAG="tagged-$COMMIT_TAG"
         SEMVER_REGEX='^([0-9]+\.){2}[0-9]+$';
         if [[ $INCOMING_TAG =~ $SEMVER_REGEX ]]; then
           TAG_LATEST="tag-latest";

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -23,7 +23,7 @@ phases:
     - >
       if [[ $CODEBUILD_WEBHOOK_TRIGGER == branch/* ]]; then
         BRANCH_TAG="branch-$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}')";
-      else
+      elif { "$(git branch --show-current)" != "" }
         BRANCH_TAG="branch-$(git branch --show-current)";
       fi
     - >

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -21,13 +21,13 @@ phases:
     - PACK_VERSION_TAG="pack-$PACK_VERSION"
     - REPOSITORY_URI=public.ecr.aws/uktrade/ci-image-builder
     - >
-      if [ -z $CODEBUILD_WEBHOOK_TRIGGER ]; then
+      if [[ $CODEBUILD_WEBHOOK_TRIGGER =~ branch/* ]]; then
+        BRANCH_TAG="branch-$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}')";
+      else
         BRANCH_TAG="branch-$(git branch --show-current)";
-      elif [[ $CODEBUILD_WEBHOOK_TRIGGER == branch/* ]]; then
-        BRANCH_TAG="branch_$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}')";
       fi
     - >
-      if [[ $CODEBUILD_WEBHOOK_TRIGGER == tag/* ]]; then
+      if [[ $CODEBUILD_WEBHOOK_TRIGGER =~ tag/* ]]; then
         TAG_TAG=$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}');
       fi
     - > 
@@ -42,11 +42,11 @@ phases:
     - docker build --build-arg PACK_VERSION=${PACK_VERSION} -t $REPOSITORY_URI .
     - docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$COMMIT_TAG"
     - >
-      if [ -n $BRANCH_TAG ]; then
+      if [ $BRANCH_TAG != "" ]; then
         docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$BRANCH_TAG";
       fi
     - >
-      if [ -n $TAG_TAG ]; then
+      if [ $TAG_TAG != "" ]; then
         docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$TAG_TAG";
         if [[ $TAG_TAG =~ ^(\d+\.\d+\.\d+)$ ]]; then
           docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:tag-latest";

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -33,16 +33,16 @@ phases:
         if [[ $INCOMING_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then
           TAG_LATEST="tag-latest";
         fi
-        TEST_TAG="0.0.0"
-        REGEX='^([0-9]+\.){2}[0-9]+$'
-        if [[ $TEST_TAG =~ $REGEX ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
-        TEST_TAG="0.0.0"
-        if [[ $TEST_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
-        TEST_TAG="000.000.000"
-        if [[ $TEST_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
-        TEST_TAG="a.b.c"
-        if [[ $TEST_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
       fi
+      TEST_TAG="0.0.0"
+      REGEX='^([0-9]+\.){2}[0-9]+$'
+      if [[ $TEST_TAG =~ $REGEX ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
+      TEST_TAG="0.0.0"
+      if [[ $TEST_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
+      TEST_TAG="000.000.000"
+      if [[ $TEST_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
+      TEST_TAG="a.b.c"
+      if [[ $TEST_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
     - > 
       echo "COMMIT_TAG: $COMMIT_TAG"
       echo -e "\nBRANCH_TAG: $BRANCH_TAG"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -23,11 +23,11 @@ phases:
     - >
       if [ -z $CODEBUILD_WEBHOOK_TRIGGER ]; then
         BRANCH_TAG="branch-$(git branch --show-current)";
-      elif [[ $CODEBUILD_WEBHOOK_TRIGGER == branch/*]]; then
+      elif [[ $CODEBUILD_WEBHOOK_TRIGGER == branch/* ]]; then
         BRANCH_TAG="branch_$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}')";
       fi
     - >
-      if [[ $CODEBUILD_WEBHOOK_TRIGGER == tag/*]]; then
+      if [[ $CODEBUILD_WEBHOOK_TRIGGER == tag/* ]]; then
         TAG_TAG=$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}');
       fi
     - > 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -28,8 +28,9 @@ phases:
       fi
     - >
       if [[ $CODEBUILD_WEBHOOK_TRIGGER == tag/* ]]; then
-        TAG_TAG=tag-$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}');
-        if [[ $TAG_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then
+        COMMIT_TAG=$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}');
+        TAG_TAG="tag-$COMMIT_TAG";
+        if [[ $COMMIT_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then
           TAG_LATEST="tag-latest";
         fi
       fi
@@ -60,6 +61,7 @@ phases:
 
   post_build:
     commands:
+    - if [ "${CODEBUILD_BUILD_SUCCEEDING}" != "1" ]; then echo "Image build failed"; exit; fi
     - echo Build completed on `date`
     - echo pushing to repo
     - docker push -a $REPOSITORY_URI

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -35,22 +35,12 @@ phases:
           TAG_LATEST="tag-latest";
         fi
       fi
-    - TEST_TAG="0.0.0"
-    - REGEX='^([0-9]+\.){2}[0-9]+$'
-    - if [[ $TEST_TAG =~ $REGEX ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
-    - TEST_TAG="0.0.0"
-    - if [[ $TEST_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
-    - TEST_TAG="000.000.000"
-    - if [[ $TEST_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
-    - TEST_TAG="a.b.c"
-    - if [[ $TEST_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
     - > 
       echo "COMMIT_TAG: $COMMIT_TAG"
       echo -e "\nBRANCH_TAG: $BRANCH_TAG"
       echo -e "\nTAG_TAG: $TAG_TAG"
       echo -e "\nTAG_LATEST: $TAG_LATEST"
       echo -e "\nPACK_VERSION_TAG: $PACK_VERSION_TAG"
-    - exit 1
   build:
     commands:
     - echo Build started on `date`

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -34,6 +34,7 @@ phases:
           TAG_LATEST="tag-latest";
         fi
       fi
+    - >
       TEST_TAG="0.0.0"
       REGEX='^([0-9]+\.){2}[0-9]+$'
       if [[ $TEST_TAG =~ $REGEX ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -30,6 +30,7 @@ phases:
       if [[ $CODEBUILD_WEBHOOK_TRIGGER == tag/* ]]; then
         INCOMING_TAG=$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}');
         TAG_TAG="tag-$INCOMING_TAG";
+        COMMIT_TAG="tagged-$COMMIT_TAG"
         SEMVER_REGEX='^([0-9]+\.){2}[0-9]+$';
         if [[ $INCOMING_TAG =~ $SEMVER_REGEX ]]; then
           TAG_LATEST="tag-latest";

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -21,14 +21,14 @@ phases:
     - PACK_VERSION_TAG="pack-$PACK_VERSION"
     - REPOSITORY_URI=public.ecr.aws/uktrade/ci-image-builder
     - >
-      if [[ $CODEBUILD_WEBHOOK_TRIGGER =~ branch/* ]]; then
+      if [[ $CODEBUILD_WEBHOOK_TRIGGER == branch/* ]]; then
         BRANCH_TAG="branch-$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}')";
       else
         BRANCH_TAG="branch-$(git branch --show-current)";
       fi
     - >
-      if [[ $CODEBUILD_WEBHOOK_TRIGGER =~ tag/* ]]; then
-        TAG_TAG=$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}');
+      if [[ $CODEBUILD_WEBHOOK_TRIGGER == tag/* ]]; then
+        TAG_TAG=tag-$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}');
       fi
     - > 
       echo "COMMIT_TAG: $COMMIT_TAG"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -23,7 +23,7 @@ phases:
     - >
       if [[ $CODEBUILD_WEBHOOK_TRIGGER == branch/* ]]; then
         BRANCH_TAG="branch-$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}')";
-      elif { "$(git branch --show-current)" != "" }
+      elif [ "$(git branch --show-current)" != "" ]; then
         BRANCH_TAG="branch-$(git branch --show-current)";
       fi
     - >

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -29,11 +29,15 @@ phases:
     - >
       if [[ $CODEBUILD_WEBHOOK_TRIGGER == tag/* ]]; then
         TAG_TAG=tag-$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}');
+        if [[ $TAG_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then
+          TAG_LATEST="tag-latest";
+        fi
       fi
     - > 
       echo "COMMIT_TAG: $COMMIT_TAG"
       echo -e "\nBRANCH_TAG: $BRANCH_TAG"
       echo -e "\nTAG_TAG: $TAG_TAG"
+      echo -e "\nTAG_LATEST: $TAG_LATEST"
       echo -e "\nPACK_VERSION_TAG: $PACK_VERSION_TAG"
   build:
     commands:
@@ -48,8 +52,8 @@ phases:
     - >
       if [ $TAG_TAG != "" ]; then
         docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$TAG_TAG";
-        if [[ $TAG_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then
-          docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:tag-latest";
+        if [ $TAG_LATEST != ""]; then
+          docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$TAG_LATEST";
         fi
       fi
     - docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$PACK_VERSION_TAG"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -30,7 +30,8 @@ phases:
       if [[ $CODEBUILD_WEBHOOK_TRIGGER == tag/* ]]; then
         INCOMING_TAG=$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}');
         TAG_TAG="tag-$INCOMING_TAG";
-        if [[ $INCOMING_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then
+        SEMVER_REGEX='^([0-9]+\.){2}[0-9]+$';
+        if [[ $INCOMING_TAG =~ $SEMVER_REGEX ]]; then
           TAG_LATEST="tag-latest";
         fi
       fi

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -42,11 +42,11 @@ phases:
     - docker build --build-arg PACK_VERSION=${PACK_VERSION} -t $REPOSITORY_URI .
     - docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$COMMIT_TAG"
     - >
-      if [ -z $BRANCH_TAG ]; then
+      if [ -n $BRANCH_TAG ]; then
         docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$BRANCH_TAG";
       fi
     - >
-      if [ -z $TAG_TAG ]; then
+      if [ -n $TAG_TAG ]; then
         docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$TAG_TAG";
       fi
     - docker tag $REPOSITORY_URI:latest "$REPOSITORY_URI:$PACK_VERSION_TAG"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -30,6 +30,7 @@ phases:
       if [[ $CODEBUILD_WEBHOOK_TRIGGER == tag/* ]]; then
         INCOMING_TAG=$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}');
         TAG_TAG="tag-$INCOMING_TAG";
+        # So it doesn't lose the "commit-*" tag from the image built from the untagged commit and lose our audit trail
         COMMIT_TAG="tagged-$COMMIT_TAG"
         SEMVER_REGEX='^([0-9]+\.){2}[0-9]+$';
         if [[ $INCOMING_TAG =~ $SEMVER_REGEX ]]; then

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -28,11 +28,20 @@ phases:
       fi
     - >
       if [[ $CODEBUILD_WEBHOOK_TRIGGER == tag/* ]]; then
-        COMMIT_TAG=$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}');
-        TAG_TAG="tag-$COMMIT_TAG";
-        if [[ $COMMIT_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then
+        INCOMING_TAG=$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}');
+        TAG_TAG="tag-$INCOMING_TAG";
+        if [[ $INCOMING_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then
           TAG_LATEST="tag-latest";
         fi
+        TEST_TAG="0.0.0"
+        REGEX='^([0-9]+\.){2}[0-9]+$'
+        if [[ $TEST_TAG =~ $REGEX ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
+        TEST_TAG="0.0.0"
+        if [[ $TEST_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
+        TEST_TAG="000.000.000"
+        if [[ $TEST_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
+        TEST_TAG="a.b.c"
+        if [[ $TEST_TAG =~ '^([0-9]+\.){2}[0-9]+$' ]]; then echo "$TEST_TAG is semver"; else echo "$TEST_TAG not semver"; fi
       fi
     - > 
       echo "COMMIT_TAG: $COMMIT_TAG"
@@ -40,6 +49,7 @@ phases:
       echo -e "\nTAG_TAG: $TAG_TAG"
       echo -e "\nTAG_LATEST: $TAG_LATEST"
       echo -e "\nPACK_VERSION_TAG: $PACK_VERSION_TAG"
+    - exit 1
   build:
     commands:
     - echo Build started on `date`


### PR DESCRIPTION
To reduce risk of ruining loads of people's day by allowing them and us to use `tag-latest` to reference the latest stable release in our pipelines.

Example tagged images:

Untagged commit

<img width="219" alt="image" src="https://github.com/user-attachments/assets/4c1c8627-a575-45bc-81c5-60550187807f">

Tagged commit

<img width="230" alt="image" src="https://github.com/user-attachments/assets/f978f684-f0e7-4ec5-8934-ae7993e0ddd6">

