### PR TITLE
Update builder_configuration.yml

### DIFF
--- a/image_builder/configuration/builder_configuration.yml
+++ b/image_builder/configuration/builder_configuration.yml
@@ -11,6 +11,7 @@ builders:
       - version: 0.3.288
   - name: paketobuildpacks/builder-jammy-base
     versions:
+      - version: 0.4.378
       - version: 0.4.279
       - version: 0.4.278
       - version: 0.4.258


### PR DESCRIPTION
Can we upgrade the builder version to 0.4.378 to allow python 3.9.21 installed