### PR TITLE
feat: dbtp 1659 datadog

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -19,7 +19,7 @@ phases:
     - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
     - COMMIT_TAG="commit-$COMMIT_HASH"
     - PACK_VERSION_TAG="pack-$PACK_VERSION"
-    - REPOSITORY_URI=public.ecr.aws/uktrade/ci-image-builder-dbtp-1659-datadog
+    - REPOSITORY_URI=public.ecr.aws/uktrade/ci-image-builder
     - >
       if [[ $CODEBUILD_WEBHOOK_TRIGGER == branch/* ]]; then
         BRANCH_TAG="branch-$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}')";

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -19,7 +19,7 @@ phases:
     - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
     - COMMIT_TAG="commit-$COMMIT_HASH"
     - PACK_VERSION_TAG="pack-$PACK_VERSION"
-    - REPOSITORY_URI=public.ecr.aws/uktrade/ci-image-builder
+    - REPOSITORY_URI=public.ecr.aws/uktrade/ci-image-builder-dbtp-1659-datadog
     - >
       if [[ $CODEBUILD_WEBHOOK_TRIGGER == branch/* ]]; then
         BRANCH_TAG="branch-$(echo $CODEBUILD_WEBHOOK_TRIGGER | awk -F "/" '{print $2}')";

--- a/image_builder/codebase/revision.py
+++ b/image_builder/codebase/revision.py
@@ -22,7 +22,14 @@ class Revision:
     commit: str
     tag: str
 
-    def __init__(self, remote: str, commit: str, long_commit: str, tag: str = None, branch: str = None):
+    def __init__(
+        self,
+        remote: str,
+        commit: str,
+        long_commit: str,
+        tag: str = None,
+        branch: str = None,
+    ):
         self.branch = branch
         self.commit = commit
         self.long_commit = long_commit

--- a/image_builder/codebase/revision.py
+++ b/image_builder/codebase/revision.py
@@ -22,9 +22,10 @@ class Revision:
     commit: str
     tag: str
 
-    def __init__(self, remote: str, commit: str, tag: str = None, branch: str = None):
+    def __init__(self, remote: str, commit: str, long_commit: str, tag: str = None, branch: str = None):
         self.branch = branch
         self.commit = commit
+        self.long_commit = long_commit
         self.tag = tag
         self.remote = remote
         if not (self.remote or self.branch or self.tag):
@@ -103,6 +104,8 @@ def load_codebase_revision(path: Path):
                     tag = possible_tag.split(" ")[1]
                     tag = tag.replace("refs/tags/", "")
                     break
+    else:
+        long_commit = None
 
     if (
         tag is None
@@ -120,4 +123,4 @@ def load_codebase_revision(path: Path):
     else:
         remote = None
 
-    return Revision(remote, commit, tag=tag, branch=branch)
+    return Revision(remote, commit, long_commit, tag=tag, branch=branch)

--- a/image_builder/pack.py
+++ b/image_builder/pack.py
@@ -121,6 +121,10 @@ class Pack:
 
         if self.codebase.revision.tag:
             environment.append(f"BPE_GIT_TAG={self.codebase.revision.tag}")
+            # DD environment parameter
+            environment.append(f"BPE_DD_VERSION={self.codebase.revision.tag}")
+        else:
+            environment.append(f"BPE_DD_VERSION={self.codebase.revision.commit}")
 
         if self.codebase.revision.commit:
             environment.append(f"BPE_GIT_COMMIT={self.codebase.revision.commit}")
@@ -139,7 +143,6 @@ class Pack:
         environment.append(
             f"BPE_DD_GIT_REPOSITORY_URL={self.codebase.revision.get_repository_url()}"
         )
-        environment.append(f"BPE_DD_VERSION={self.codebase.revision.commit}")
         environment.append(f"BPE_DD_GIT_COMMIT_SHA={self.codebase.revision.long_commit}")
 
         additional_labels = []

--- a/image_builder/pack.py
+++ b/image_builder/pack.py
@@ -135,6 +135,8 @@ class Pack:
             f"BP_OCI_SOURCE={self.codebase.revision.get_repository_url()}"
         )
 
+        environment.append("BPE_DD_VERSION_SET=this_is_test")
+
         additional_labels = []
 
         if self.build_timestamp is not None:

--- a/image_builder/pack.py
+++ b/image_builder/pack.py
@@ -137,10 +137,10 @@ class Pack:
 
         # DD environment parameters.
         environment.append(
-            f"BPE_DD_GIT_REPOSITORY_URL_2={self.codebase.revision.get_repository_url()}"
+            f"BPE_DD_GIT_REPOSITORY_URL={self.codebase.revision.get_repository_url()}"
         )
-        environment.append(f"BPE_DD_VERSION_2={self.codebase.revision.commit}")
-        environment.append(f"BPE_DD_GIT_COMMIT_SHA_2={self.codebase.revision.long_commit}")
+        environment.append(f"BPE_DD_VERSION={self.codebase.revision.commit}")
+        environment.append(f"BPE_DD_GIT_COMMIT_SHA={self.codebase.revision.long_commit}")
 
         additional_labels = []
 

--- a/image_builder/pack.py
+++ b/image_builder/pack.py
@@ -143,7 +143,9 @@ class Pack:
         environment.append(
             f"BPE_DD_GIT_REPOSITORY_URL={self.codebase.revision.get_repository_url()}"
         )
-        environment.append(f"BPE_DD_GIT_COMMIT_SHA={self.codebase.revision.long_commit}")
+        environment.append(
+            f"BPE_DD_GIT_COMMIT_SHA={self.codebase.revision.long_commit}"
+        )
 
         additional_labels = []
 

--- a/image_builder/pack.py
+++ b/image_builder/pack.py
@@ -135,7 +135,12 @@ class Pack:
             f"BP_OCI_SOURCE={self.codebase.revision.get_repository_url()}"
         )
 
-        environment.append("BPE_DD_VERSION_SET=this_is_test")
+        # DD environment parameters.
+        environment.append(
+            f"BPE_DD_GIT_REPOSITORY_URL_2={self.codebase.revision.get_repository_url()}"
+        )
+        environment.append(f"BPE_DD_VERSION_2={self.codebase.revision.commit}")
+        environment.append(f"BPE_DD_GIT_COMMIT_SHA_2={self.codebase.revision.long_commit}")
 
         additional_labels = []
 

--- a/test/doubles/codebase.py
+++ b/test/doubles/codebase.py
@@ -32,5 +32,5 @@ def load_codebase_processes_double(path):
 
 def load_codebase_revision_double(path) -> Revision:
     return Revision(
-        "git@github.com:org/repo.git", "shorthash", branch="feat/tests", tag="v2.4.6"
+        "git@github.com:org/repo.git", "shorthash", "longhash", branch="feat/tests", tag="v2.4.6"
     )

--- a/test/doubles/codebase.py
+++ b/test/doubles/codebase.py
@@ -32,5 +32,9 @@ def load_codebase_processes_double(path):
 
 def load_codebase_revision_double(path) -> Revision:
     return Revision(
-        "git@github.com:org/repo.git", "shorthash", "longhash", branch="feat/tests", tag="v2.4.6"
+        "git@github.com:org/repo.git",
+        "shorthash",
+        "longhash",
+        branch="feat/tests",
+        tag="v2.4.6",
     )

--- a/test/image_builder/codebase/test_revision.py
+++ b/test/image_builder/codebase/test_revision.py
@@ -55,6 +55,7 @@ class TestCodebaseRevision(BaseTestCase):
         revision = load_codebase_revision(Path("."))
 
         self.assertEqual(revision.commit, "shorthash")
+        self.assertEqual(revision.long_commit, "longhash")
         self.assertEqual(revision.branch, "main")
         self.assertEqual(revision.tag, "2.0.0")
         self.assertEqual(revision.get_repository_name(), "org/repo")

--- a/test/image_builder/test_pack.py
+++ b/test/image_builder/test_pack.py
@@ -246,7 +246,10 @@ class TestPackEnvironment(BaseTestCase):
             "image_builder.codebase.codebase.load_codebase_revision",
             mock.Mock(
                 return_value=Revision(
-                    "git@github.com:org/repo.git", "shorthash", "longhash", branch="feat/tests"
+                    "git@github.com:org/repo.git",
+                    "shorthash",
+                    "longhash",
+                    branch="feat/tests",
                 )
             ),
         ):

--- a/test/image_builder/test_pack.py
+++ b/test/image_builder/test_pack.py
@@ -215,12 +215,15 @@ class TestPackEnvironment(BaseTestCase):
                 "BP_NODE_VERSION=20.7",
                 "BP_RUBY_VERSION=3.3",
                 "BPE_GIT_TAG=v2.4.6",
+                "BPE_DD_VERSION=v2.4.6",
                 "BPE_GIT_COMMIT=shorthash",
                 "BP_OCI_REVISION=shorthash",
                 "BP_OCI_VERSION=shorthash",
                 "BPE_GIT_BRANCH=feat/tests",
                 "BP_OCI_REF_NAME=tag-v2.4.6",
                 "BP_OCI_SOURCE=https://github.com/org/repo",
+                "BPE_DD_GIT_REPOSITORY_URL=https://github.com/org/repo",
+                "BPE_DD_GIT_COMMIT_SHA=longhash",
                 'BP_IMAGE_LABELS="uk.gov.trade.digital.build.timestamp=timestamp"',
             ],
         )
@@ -243,7 +246,7 @@ class TestPackEnvironment(BaseTestCase):
             "image_builder.codebase.codebase.load_codebase_revision",
             mock.Mock(
                 return_value=Revision(
-                    "git@github.com:org/repo.git", "shorthash", branch="feat/tests"
+                    "git@github.com:org/repo.git", "shorthash", "longhash", branch="feat/tests"
                 )
             ),
         ):
@@ -324,12 +327,15 @@ class TestCommand(BaseTestCase):
             "--env BP_NODE_VERSION=20.7",
             "--env BP_RUBY_VERSION=3.3",
             "--env BPE_GIT_TAG=v2.4.6",
+            "--env BPE_DD_VERSION=v2.4.6",
             "--env BPE_GIT_COMMIT=shorthash",
             "--env BP_OCI_REVISION=shorthash",
             "--env BP_OCI_VERSION=shorthash",
             "--env BPE_GIT_BRANCH=feat/tests",
             "--env BP_OCI_REF_NAME=tag-v2.4.6",
             "--env BP_OCI_SOURCE=https://github.com/org/repo",
+            "--env BPE_DD_GIT_REPOSITORY_URL=https://github.com/org/repo",
+            "--env BPE_DD_GIT_COMMIT_SHA=longhash",
             '--env BP_IMAGE_LABELS="uk.gov.trade.digital.build.timestamp=timestamp"',
             "--buildpack paketo-buildpacks/git",
             "--buildpack paketo-buildpacks/python",


### PR DESCRIPTION
Add environment variables required during run time for DataDog codebase tracking.

DD_VERSION: <short-git-commit/git-tag>
DD_GIT_COMMIT_SHA: <long-git-commit>
DD_GIT_REPOSITORY_URL: <git-repository-url>