### PR TITLE
ci: Set Dependabot prefixes & don't lint release titles (DBTP-1924)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      # So the release-please-action includes production
+      # dependencies in the release notes.
+      prefix: "deps"
+      # Don't include dev dependencies in release notes, they
+      # are of no interest outside this repository's maintainers.
+      prefix-development: "chore(deps-dev)"

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -26,6 +26,7 @@ jobs:
           subjectPatternError: |
             The subject "{subject}" found in the pull request title "{title}"
             didn't match the expected pattern. E.g. "feat: Add new feature (DBTP-1234)".
-          # Do not check Dependabot pull requests as we do no control the titles
+          # Do not check pull requests where us taking control of the titles is either not possible, or would add more overhead than value
           ignoreLabels: |
+            autorelease: pending
             dependencies


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-1924.

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
- [x] Link to ticket included (unless it's a quick out of ticket thing)
- [ ] Includes tests (or an explanation for why it doesn't)
- [ ] Includes any applicable changes to the documentation in this code base
- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)
