### PR TITLE
fix: Buildpack images not found (off-ticket)

### DIFF
--- a/image_builder/pack.py
+++ b/image_builder/pack.py
@@ -111,8 +111,8 @@ class Pack:
                 buildpacks.append("paketo-buildpacks/php")
 
         buildpacks.append("fagiani/run")
-        buildpacks.append("gcr.io/paketo-buildpacks/image-labels")
-        buildpacks.append("gcr.io/paketo-buildpacks/environment-variables")
+        buildpacks.append("paketo-buildpacks/image-labels@4.9.0")
+        buildpacks.append("paketo-buildpacks/environment-variables@4.9.0")
 
         return buildpacks
 

--- a/test/image_builder/test_pack.py
+++ b/test/image_builder/test_pack.py
@@ -82,8 +82,8 @@ class TestPackBuildpacks(BaseTestCase):
                 "paketo-buildpacks/ruby",
                 "paketo-buildpacks/php",
                 "fagiani/run",
-                "gcr.io/paketo-buildpacks/image-labels",
-                "gcr.io/paketo-buildpacks/environment-variables",
+                "paketo-buildpacks/image-labels@4.9.0",
+                "paketo-buildpacks/environment-variables@4.9.0",
             ],
         )
 
@@ -116,8 +116,8 @@ class TestPackBuildpacks(BaseTestCase):
                 "paketo-buildpacks/ruby",
                 "paketo-buildpacks/php",
                 "fagiani/run",
-                "gcr.io/paketo-buildpacks/image-labels",
-                "gcr.io/paketo-buildpacks/environment-variables",
+                "paketo-buildpacks/image-labels@4.9.0",
+                "paketo-buildpacks/environment-variables@4.9.0",
             ],
         )
 
@@ -154,8 +154,8 @@ class TestPackBuildpacks(BaseTestCase):
                 "paketo-buildpacks/ruby",
                 "paketo-buildpacks/php",
                 "fagiani/run",
-                "gcr.io/paketo-buildpacks/image-labels",
-                "gcr.io/paketo-buildpacks/environment-variables",
+                "paketo-buildpacks/image-labels@4.9.0",
+                "paketo-buildpacks/environment-variables@4.9.0",
             ],
         )
 
@@ -353,8 +353,8 @@ class TestCommand(BaseTestCase):
             "--buildpack paketo-buildpacks/ruby",
             "--buildpack paketo-buildpacks/php",
             "--buildpack fagiani/run",
-            "--buildpack gcr.io/paketo-buildpacks/image-labels",
-            "--buildpack gcr.io/paketo-buildpacks/environment-variables",
+            "--buildpack paketo-buildpacks/image-labels@4.9.0",
+            "--buildpack paketo-buildpacks/environment-variables@4.9.0",
         ]
         self.publish_opts = "--publish --cache-image 000000000000.dkr.ecr.region.amazonaws.com/ecr/repos:cache"
         self.run_image_opt = "--run-image nice-secure-base-image"


### PR DESCRIPTION
Addresses errors seen in build jobs:

```shell
Error: ERROR: failed to build: downloading buildpack: extracting from registry 'gcr.io/paketo-buildpacks/image-labels': fetching image: connect to repo store "gcr.io/paketo-buildpacks/image-labels"
```

---
## Checklist:

### Title:
- [x] Conforms to [our pull request title guidance](https://uktrade.atlassian.net/wiki/spaces/DBTP/pages/4402020487/Git+housekeeping#Pull-request-titles). E.g. `feat: Add new feature (DBTP-1234)` or `chore: Correct typo (off-ticket)`

### Description:
~~- [ ] Link to ticket included (unless it's a quick out of ticket thing)~~

- [x] Includes tests (or an explanation for why it doesn't)

~~- [ ] Includes any applicable changes to the documentation in this code base~~
~~- [ ] Includes link(s) to any applicable changes to the documentation in the [DBT Platform Documentation](https://platform.readme.trade.gov.uk/) (can be to a pull request)~~
